### PR TITLE
Add /health, /radar_files, /radar_filter_q

### DIFF
--- a/.github/workflows/hourly-level3-download.yml
+++ b/.github/workflows/hourly-level3-download.yml
@@ -1,0 +1,45 @@
+name: Download latest Level 3 radar data
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  fetch-latest-level3:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install boto3
+
+      - name: Download latest Level 3 data
+        run: |
+          python scripts/download_latest_level3.py --target-dir radar_3_data
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add radar_3_data
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            git commit -m "Update Level 3 radar data ($timestamp)"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.env
+.env.*
+*.sqlite3
+static/radar_filter.png
+static/radar_filter.jpg
+.radarlib/

--- a/CODEX_REPORT.md
+++ b/CODEX_REPORT.md
@@ -1,19 +1,30 @@
 # CODEX Report
 
-## Frameworks Detected
-- **Flask** (`app.py`) provides the HTTP API and static file hosting.
-- **MetPy**, **Cartopy**, and **Matplotlib** (`services/radar_processing.py`) render Level III radar data into images.
-- **Leaflet** (`static/radar.html`, `static/js/radar.js`) powers the interactive browser map overlay.
+## Framework & Entry Point
+- **Flask** application instantiated in `app.py` (`app = Flask(__name__, static_folder="static", static_url_path="/static")`).
 
-## Key Files
-- `services/data_sources/base.py`: Abstract data-source contract.
-- `services/data_sources/s3_source.py`: AWS S3 implementation for Level III products.
-- `services/data_sources/thread_source.py`: NOAA/NCEI thread server implementation.
-- `services/radar_processing.py`: Core radar-to-image conversion utilities.
-- `app.py`: Flask entry point exposing `/api/files` and `/api/file` for the front-end.
-- `static/radar.html` & `static/js/radar.js`: HTML/JS client for browsing and filtering radar products.
+## Registered Routes (`app.url_map`)
+- `/static/<path:filename>` → Flask static file handler
+- `/` → `index`
+- `/radar_filter/<path:path>/<int:filtered_amount>` → `subset_radar_file`
+- `/health` → `health`
+- `/radar_files` → `radar_files`
+- `/radar_filter_q` → `radar_filter_q`
+- `/api/files` → `api_files`
+- `/api/file` → `api_file`
 
-## Gaps & Notes
-- Thread server catalogue parsing assumes access to a `catalog.xml` listing; additional work may be needed for alternate deployments.
-- Geographic bounds are approximated from polar coordinate transforms and may need refinement for specific products.
-- Large data processing remains CPU-intensive; consider caching rendered images for repeated threshold adjustments.
+## Static File Origin
+- Static assets are served from the repository’s `static/` directory (copied to `/app/static` inside the container by the Dockerfile).
+
+## Response Headers (captured via Flask test client)
+- **GET `/static/radar.html`**
+  - `Content-Type: text/html; charset=utf-8`
+- **GET `/static/radar.js`**
+  - `Content-Type: application/javascript`
+- **GET `/radar_files`**
+  - `Content-Type: application/json`
+- **GET `/radar_filter_q?path=radar_3_data/KMLB_SDUS52_TZ0MCO_202405151906.nc&threshold=23`**
+  - `Content-Type: image/png`
+  - `Cache-Control: no-store`
+  - `X-Radar-Source-Path: radar_3_data/KMLB_SDUS52_TZ0MCO_202405151906.nc`
+  - `X-Radar-Bounds: …` *(present when geographic bounds are available for the product)*

--- a/CODEX_REPORT.md
+++ b/CODEX_REPORT.md
@@ -1,0 +1,19 @@
+# CODEX Report
+
+## Frameworks Detected
+- **Flask** (`app.py`) provides the HTTP API and static file hosting.
+- **MetPy**, **Cartopy**, and **Matplotlib** (`services/radar_processing.py`) render Level III radar data into images.
+- **Leaflet** (`static/radar.html`, `static/js/radar.js`) powers the interactive browser map overlay.
+
+## Key Files
+- `services/data_sources/base.py`: Abstract data-source contract.
+- `services/data_sources/s3_source.py`: AWS S3 implementation for Level III products.
+- `services/data_sources/thread_source.py`: NOAA/NCEI thread server implementation.
+- `services/radar_processing.py`: Core radar-to-image conversion utilities.
+- `app.py`: Flask entry point exposing `/api/files` and `/api/file` for the front-end.
+- `static/radar.html` & `static/js/radar.js`: HTML/JS client for browsing and filtering radar products.
+
+## Gaps & Notes
+- Thread server catalogue parsing assumes access to a `catalog.xml` listing; additional work may be needed for alternate deployments.
+- Geographic bounds are approximated from polar coordinate transforms and may need refinement for specific products.
+- Large data processing remains CPU-intensive; consider caching rendered images for repeated threshold adjustments.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ COPY requirements.txt /app
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 COPY . /app
-RUN mkdir /app/static
+RUN mkdir -p /app/static
 EXPOSE 5000
 CMD [ "python", "app.py" ]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,61 @@
 # Level 3 Radar Widget Practice
-#### To run you must have docker installed and running on your computer
-`https://docs.docker.com/engine/install/`
 
-#### Next, spin up the container and build the image that the application will run off of
-`docker compose up`
+## Prerequisites
+- Python 3.11+
+- (Optional) Docker if you prefer containerised development.
 
-### RADAR FILTERING SERVICE
-#### This filter will remove all dBZ values in the file below a specific number
-#### Submit a url with the path of the radar file that you would like to filter down along with the dBZ value you would like to filter based off of.
-#### Schema: localhost/radar_filter/path-to-file/dBZ-filter
-#### Test:
-`http://localhost:5000/radar_filter/radar_3_data%2FKMLB_SDUS52_TZ0MCO_202405151912/23`
+## Environment Configuration
+Create a `.env` file in the project root with the following variables:
+
+```
+AWS_REGION=us-east-1
+AWS_PROFILE=
+S3_BUCKET=unidata-nexrad-level3
+THREAD_SERVER_URL=<https://example/thredds/catalog/path>
+```
+
+`AWS_PROFILE` is optional; leave it blank to use the default AWS credential chain.
+
+## Local Development
+1. Create a virtual environment and install dependencies:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. Start the Flask server:
+   ```bash
+   python app.py
+   ```
+   The API listens on `http://localhost:5000` by default.
+
+Alternatively, you can run the existing Docker setup:
+```bash
+docker compose up
+```
+
+## Radar Viewer
+1. Ensure the Flask server is running.
+2. Open `static/radar.html` in a browser (e.g. `http://localhost:5000/static/radar.html`).
+3. Choose a data source (S3 or NOAA/NCEI Thread), optionally provide a prefix filter and limit, then click **Fetch files**.
+4. Click a key from the list to render the radar product.
+5. Adjust the DBZ threshold slider or number input to re-render the current product without reloading the page.
+6. Toggle **Map overlay** to switch between Leaflet map overlay (when geographic bounds are available) and the standalone image view.
+7. Use the **Quick test** button to automatically load the known good dataset:
+   - Source: S3
+   - Key: `TBW_N0B_2025_06_15_19_01_56`
+   - Threshold: `23`
+
+If the backend cannot compute bounds for a product, the viewer automatically falls back to the standalone image display.
+
+## Testing
+Run the unit tests with:
+```bash
+pytest
+```
+
+## Legacy Filter Route
+The original filter endpoint is still available for compatibility:
+```
+http://localhost:5000/radar_filter/radar_3_data%2FKMLB_SDUS52_TZ0MCO_202405151912/23
+```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ S3_BUCKET=unidata-nexrad-level3
 THREAD_SERVER_URL=<https://example/thredds/catalog/path>
 ```
 
-`AWS_PROFILE` is optional; leave it blank to use the default AWS credential chain.
+`AWS_PROFILE` is optional; leave it blank to use the default AWS credential chain. The
+`AWS_REGION` and `S3_BUCKET` defaults match the public Level III bucket and are safe to
+commit for local development.
 
 ## Local Development
 1. Create a virtual environment and install dependencies:
@@ -34,19 +36,32 @@ Alternatively, you can run the existing Docker setup:
 docker compose up
 ```
 
-## Radar Viewer
-1. Ensure the Flask server is running.
-2. Open `static/radar.html` in a browser (e.g. `http://localhost:5000/static/radar.html`).
-3. Choose a data source (S3 or NOAA/NCEI Thread), optionally provide a prefix filter and limit, then click **Fetch files**.
-4. Click a key from the list to render the radar product.
-5. Adjust the DBZ threshold slider or number input to re-render the current product without reloading the page.
-6. Toggle **Map overlay** to switch between Leaflet map overlay (when geographic bounds are available) and the standalone image view.
-7. Use the **Quick test** button to automatically load the known good dataset:
-   - Source: S3
-   - Key: `TBW_N0B_2025_06_15_19_01_56`
-   - Threshold: `23`
+## Last-hour ingest workflow
 
-If the backend cannot compute bounds for a product, the viewer automatically falls back to the standalone image display.
+The project includes a helper to pull the latest 60 minutes of Level III base reflectivity
+products and seed the local cache:
+
+```bash
+export AWS_REGION=us-east-1
+export S3_BUCKET=unidata-nexrad-level3
+# optional filters
+export SITES=KMLB,KJAX,KMIA,KTBW
+export MINUTES=60
+python scripts/ingest_last_hour.py
+```
+
+The script populates `radar_3_data/latest/` via the shared cache layer and writes a
+timestamped copy to `radar_3_data/hourly/<YYYYMMDDHH>/`.
+
+## Radar Viewer
+1. Ensure the Flask server is running (`python app.py`) and visit `http://localhost:5000/`.
+2. Choose a **Data source** (`local`, `s3`, or `thread`). The UI defaults to the local cache
+   for reliability and will automatically fall back if a remote source returns a 5xx error.
+3. Use the **Location** and **Search radar** drop-downs to filter by city/state or call sign.
+4. Select a radar to view the four tilt cards (overview + zoom) generated from the cached
+   Level III files.
+5. If no products appear, run `scripts/ingest_last_hour.py` to refresh the cache or switch
+   to a different source.
 
 ## Testing
 Run the unit tests with:

--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
+import subprocess
+import sys
 from io import BytesIO
 from mimetypes import add_type
 from pathlib import Path
@@ -12,7 +14,7 @@ from flask import Flask, jsonify, make_response, render_template, request, send_
 from flask_cors import CORS
 
 from run_radar_analysis import Filter
-from services.data_sources import S3DataSource, ThreadDataSource
+from services.data_sources import LocalDataSource, S3DataSource, ThreadDataSource
 from services.data_sources.base import BaseDataSource
 from services import local_cache
 from services.radar_catalog import (
@@ -27,6 +29,8 @@ add_type("application/javascript", ".js")
 
 load_dotenv()
 
+logging.basicConfig(level=logging.INFO)
+
 app = Flask(__name__, static_folder="static", static_url_path="/static")
 CORS(app, resources={r"/api/*": {"origins": "*"}})
 
@@ -34,6 +38,7 @@ CORS(app, resources={r"/api/*": {"origins": "*"}})
 _DATA_SOURCE_FACTORIES = {
     "s3": S3DataSource,
     "thread": ThreadDataSource,
+    "local": LocalDataSource,
 }
 
 _data_source_cache: Dict[str, BaseDataSource] = {}
@@ -50,7 +55,7 @@ def get_data_source(name: str) -> BaseDataSource:
 
 @app.route('/')
 def index():
-    return 'App Works!'
+    return app.send_static_file("radar.html")
 
 
 @app.route('/radar_filter/<path:path>/<int:filtered_amount>')
@@ -216,13 +221,32 @@ def api_latest_base_reflectivity():
     limit = request.args.get("limit", default=50, type=int)
     search_limit = request.args.get("search_limit", default=max(limit * 25, 400), type=int)
 
+    requested_source = source
+    active_source = requested_source
     try:
-        data_source = get_data_source(source)
+        data_source = get_data_source(requested_source)
         keys = data_source.list_keys(prefix=prefix, limit=search_limit)
     except ValueError as exc:
         return jsonify(error=str(exc)), 400
     except Exception as exc:  # pragma: no cover - defensive guard
-        return jsonify(error=str(exc)), 502
+        app.logger.exception("%s list_keys failed: %s", requested_source, exc)
+        if requested_source != "local":
+            try:
+                data_source = get_data_source("local")
+                keys = data_source.list_keys(prefix=prefix, limit=search_limit)
+                active_source = "local"
+            except Exception:
+                app.logger.exception("Local fallback also failed")
+                return (
+                    jsonify(
+                        error=(
+                            f"{requested_source.upper()} error and no local fallback: {str(exc)}"
+                        )
+                    ),
+                    502,
+                )
+        else:
+            return jsonify(error=str(exc)), 502
 
     latest = latest_by_radar(keys)
     radars = []
@@ -243,7 +267,10 @@ def api_latest_base_reflectivity():
                 downloaded[parsed.key] = file_bytes
             except Exception as exc:  # pragma: no cover - defensive guard
                 logging.getLogger(__name__).warning(
-                    "Unable to download %s from %s: %s", parsed.key, source, exc
+                    "Unable to download %s from %s: %s",
+                    parsed.key,
+                    active_source,
+                    exc,
                 )
             product_entries.append(
                 {
@@ -291,11 +318,27 @@ def api_latest_base_reflectivity():
     return jsonify(
         radars=radars,
         count=len(radars),
+        source=active_source,
         products=[
             {"code": code, "tilt_degrees": tilt}
             for code, tilt in BASE_REFLECTIVITY_TILTS.items()
         ],
     )
+
+
+@app.post("/api/ingest/last_hour")
+def api_ingest_last_hour():
+    try:
+        proc = subprocess.run(
+            [sys.executable, "scripts/ingest_last_hour.py"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        return jsonify(ok=False, error=exc.stderr or str(exc)), 500
+
+    return jsonify(ok=True, output=proc.stdout)
 
 
 """@app.route('/radar_summary/<path:path>')

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
-from flask import Flask, render_template, url_for
+from flask import Flask, render_template, url_for, jsonify, request
+from pathlib import Path
 from run_radar_analysis import Filter
 
 app = Flask(__name__)
@@ -8,13 +9,54 @@ app = Flask(__name__)
 def index():
     return 'App Works!'
 
+
 @app.route('/radar_filter/<path:path>/<int:filtered_amount>')
 def subset_radar_file(path, filtered_amount):
-
     filter_radar = Filter(path)
     my_radar_image = filter_radar.filter_dbz(filtered_amount)
-    #print (my_radar_image)
+    # Optional: pass data into the template if you want to display something later
+    # return render_template("index.html", image=my_radar_image)
     return render_template("index.html")
+
+
+# --- Brandan additions ---
+@app.get("/health")
+def health():
+    """Simple health check."""
+    return jsonify(status="ok")
+
+
+@app.get("/radar_files")
+def radar_files():
+    """List files under radar_3_data so you know what is available."""
+    base = Path("radar_3_data")
+    files = []
+    if base.exists():
+        for p in base.rglob("*"):
+            if p.is_file():
+                # return a repo-relative path for easy use in URLs
+                files.append(str(p.as_posix()))
+    return jsonify(count=len(files), files=sorted(files))
+
+
+# Example:
+#   /radar_filter_q?path=radar_3_data/KMLB_SDUS52_TZ0MCO_202405151912&threshold=23
+@app.get("/radar_filter_q")
+def radar_filter_q():
+    """Helper that returns the correct encoded route for the existing filter."""
+    path = request.args.get("path")
+    threshold = request.args.get("threshold", type=int)
+    if not path or threshold is None:
+        return jsonify(error="Provide ?path=<relative file path>&threshold=<int>"), 400
+
+    # Build the exact route to your existing endpoint. url_for handles encoding.
+    route = url_for("subset_radar_file", path=path, filtered_amount=threshold)
+    return jsonify(
+        tip="Open this route to run the filter",
+        route=route
+    )
+# --- end Brandan additions ---
+
 
 """@app.route('/radar_summary/<path:path>')
 def radar_data_summary(path):
@@ -23,7 +65,6 @@ def radar_data_summary(path):
 @app.route('/radar_images/<path:path>')
 def create_radar_image(path):
     return "my image test " + path"""
-
 
 
 if __name__ == '__main__':

--- a/app.py
+++ b/app.py
@@ -1,8 +1,38 @@
-from flask import Flask, render_template, url_for, jsonify, request
-from pathlib import Path
-from run_radar_analysis import Filter
+from __future__ import annotations
 
-app = Flask(__name__)
+import json
+from pathlib import Path
+from typing import Dict
+
+from dotenv import load_dotenv
+from flask import Flask, jsonify, make_response, render_template, request, url_for
+from flask_cors import CORS
+
+from run_radar_analysis import Filter
+from services.data_sources import S3DataSource, ThreadDataSource
+from services.data_sources.base import BaseDataSource
+
+load_dotenv()
+
+app = Flask(__name__, static_folder="static", static_url_path="/static")
+CORS(app, resources={r"/api/*": {"origins": "*"}})
+
+
+_DATA_SOURCE_FACTORIES = {
+    "s3": S3DataSource,
+    "thread": ThreadDataSource,
+}
+
+_data_source_cache: Dict[str, BaseDataSource] = {}
+
+
+def get_data_source(name: str) -> BaseDataSource:
+    name = name.lower()
+    if name not in _DATA_SOURCE_FACTORIES:
+        raise ValueError(f"Unknown data source '{name}'")
+    if name not in _data_source_cache:
+        _data_source_cache[name] = _DATA_SOURCE_FACTORIES[name]()
+    return _data_source_cache[name]
 
 
 @app.route('/')
@@ -13,9 +43,7 @@ def index():
 @app.route('/radar_filter/<path:path>/<int:filtered_amount>')
 def subset_radar_file(path, filtered_amount):
     filter_radar = Filter(path)
-    my_radar_image = filter_radar.filter_dbz(filtered_amount)
-    # Optional: pass data into the template if you want to display something later
-    # return render_template("index.html", image=my_radar_image)
+    filter_radar.filter_dbz(filtered_amount)
     return render_template("index.html")
 
 
@@ -56,6 +84,59 @@ def radar_filter_q():
         route=route
     )
 # --- end Brandan additions ---
+
+
+@app.get("/api/files")
+def api_files():
+    """Return available radar keys for the requested data source."""
+
+    source = request.args.get("source", type=str)
+    if not source:
+        return jsonify(error="Missing required 'source' parameter"), 400
+
+    prefix = request.args.get("prefix", type=str)
+    limit = request.args.get("limit", default=50, type=int)
+
+    try:
+        data_source = get_data_source(source)
+        keys = data_source.list_keys(prefix=prefix, limit=limit)
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 400
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return jsonify(error=str(exc)), 502
+
+    return jsonify(keys=keys, count=len(keys))
+
+
+@app.get("/api/file")
+def api_file():
+    """Return a processed radar image for the supplied key."""
+
+    source = request.args.get("source", type=str)
+    key = request.args.get("key", type=str)
+    threshold = request.args.get("threshold", type=int)
+
+    if not source or not key:
+        return jsonify(error="Both 'source' and 'key' parameters are required"), 400
+
+    try:
+        data_source = get_data_source(source)
+        content, metadata = data_source.get_image_for_key(key, threshold=threshold)
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 400
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return jsonify(error=str(exc)), 502
+
+    response = make_response(content)
+    content_type = metadata.get("content_type", "image/png")
+    response.headers["Content-Type"] = content_type
+
+    bounds = metadata.get("bounds")
+    if bounds:
+        response.headers["X-Radar-Bounds"] = json.dumps(bounds)
+    response.headers["X-Radar-Key"] = metadata.get("key", key)
+
+    return response
 
 
 """@app.route('/radar_summary/<path:path>')

--- a/app.py
+++ b/app.py
@@ -13,7 +13,12 @@ from flask_cors import CORS
 from run_radar_analysis import Filter
 from services.data_sources import S3DataSource, ThreadDataSource
 from services.data_sources.base import BaseDataSource
-from services.radar_processing import process_level3_bytes
+from services.radar_catalog import (
+    BASE_REFLECTIVITY_TILTS,
+    latest_by_radar,
+    sorted_products,
+)
+from services.radar_processing import process_level3_bytes, read_level3_metadata
 
 
 add_type("application/javascript", ".js")
@@ -75,14 +80,14 @@ def radar_files():
 
 # Example:
 #   /radar_filter_q?path=radar_3_data/KMLB_SDUS52_TZ0MCO_202405151912&threshold=23
-def _load_radar_image(path: Path, threshold: Optional[int]):
+def _load_radar_image(path: Path, threshold: Optional[int], view: str):
     """Render ``path`` at ``threshold`` and return processed content + metadata."""
 
     if not path.exists():
         raise FileNotFoundError(path)
 
     try:
-        processed = process_level3_bytes(path.read_bytes(), threshold)
+        processed = process_level3_bytes(path.read_bytes(), threshold, view=view)
     except Exception as exc:  # pragma: no cover - defensive guard
         raise RuntimeError(str(exc)) from exc
 
@@ -95,6 +100,7 @@ def radar_filter_q():
 
     path_value = request.args.get("path")
     threshold = request.args.get("threshold", type=int)
+    view = request.args.get("view", default="combined", type=str)
 
     if not path_value or threshold is None:
         return (
@@ -105,7 +111,7 @@ def radar_filter_q():
     candidate_path = Path(path_value)
 
     try:
-        processed = _load_radar_image(candidate_path, threshold)
+        processed = _load_radar_image(candidate_path, threshold, view)
     except FileNotFoundError:
         return jsonify(error=f"File not found: {path_value}"), 404
     except RuntimeError as exc:
@@ -119,6 +125,8 @@ def radar_filter_q():
     response.headers["X-Radar-Source-Path"] = str(candidate_path)
     if processed.bounds:
         response.headers["X-Radar-Bounds"] = json.dumps(processed.bounds)
+    if processed.metadata:
+        response.headers["X-Radar-Metadata"] = json.dumps(processed.metadata)
     return response
 # --- end Brandan additions ---
 
@@ -152,13 +160,16 @@ def api_file():
     source = request.args.get("source", type=str)
     key = request.args.get("key", type=str)
     threshold = request.args.get("threshold", type=int)
+    view = request.args.get("view", default="combined", type=str)
 
     if not source or not key:
         return jsonify(error="Both 'source' and 'key' parameters are required"), 400
 
     try:
         data_source = get_data_source(source)
-        content, metadata = data_source.get_image_for_key(key, threshold=threshold)
+        content, metadata = data_source.get_image_for_key(
+            key, threshold=threshold, view=view
+        )
     except ValueError as exc:
         return jsonify(error=str(exc)), 400
     except Exception as exc:  # pragma: no cover - defensive guard
@@ -172,8 +183,100 @@ def api_file():
     if bounds:
         response.headers["X-Radar-Bounds"] = json.dumps(bounds)
     response.headers["X-Radar-Key"] = metadata.get("key", key)
+    extras = {k: v for k, v in metadata.items() if k not in {"bounds", "key", "content_type"}}
+    if extras:
+        response.headers["X-Radar-Metadata"] = json.dumps(extras)
 
     return response
+
+
+def _normalise_radar_filter(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    value = value.strip().upper()
+    if not value:
+        return None
+    if len(value) == 3 and not value.startswith("K"):
+        value = f"K{value}"
+    return value
+
+
+@app.get("/api/base_reflectivity/latest")
+def api_latest_base_reflectivity():
+    source = request.args.get("source", type=str)
+    if not source:
+        return jsonify(error="Missing required 'source' parameter"), 400
+
+    prefix = request.args.get("prefix", type=str)
+    radar_filter = _normalise_radar_filter(request.args.get("radar"))
+    include_metadata = request.args.get("include_metadata", default="true", type=str)
+    include_metadata_flag = include_metadata.lower() not in {"false", "0", "no"}
+    limit = request.args.get("limit", default=50, type=int)
+    search_limit = request.args.get("search_limit", default=max(limit * 25, 400), type=int)
+
+    try:
+        data_source = get_data_source(source)
+        keys = data_source.list_keys(prefix=prefix, limit=search_limit)
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 400
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return jsonify(error=str(exc)), 502
+
+    latest = latest_by_radar(keys)
+    radars = []
+
+    for radar_id, products in latest.items():
+        if radar_filter and radar_id != radar_filter:
+            continue
+
+        ordered_products = sorted_products(products)
+        if not ordered_products:
+            continue
+
+        product_entries = []
+        for parsed in ordered_products:
+            product_entries.append(
+                {
+                    "code": parsed.product_code,
+                    "key": parsed.key,
+                    "timestamp": parsed.timestamp.replace(tzinfo=None).isoformat(),
+                    "tilt_degrees": BASE_REFLECTIVITY_TILTS.get(parsed.product_code),
+                }
+            )
+
+        radar_entry: Dict[str, object] = {
+            "radar_id": radar_id,
+            "raw_radar": ordered_products[0].raw_radar,
+            "products": product_entries,
+        }
+
+        if include_metadata_flag:
+            sample_key = ordered_products[0].key
+            try:
+                file_bytes = data_source.get_level3_bytes(sample_key)
+                metadata = read_level3_metadata(file_bytes)
+            except Exception:  # pragma: no cover - defensive guard
+                metadata = {}
+            radar_entry.update(metadata)
+
+        radars.append(radar_entry)
+
+    if include_metadata_flag:
+        radars.sort(key=lambda item: (item.get("location") or item["radar_id"]).upper())
+    else:
+        radars.sort(key=lambda item: item["radar_id"].upper())
+
+    if limit > 0:
+        radars = radars[:limit]
+
+    return jsonify(
+        radars=radars,
+        count=len(radars),
+        products=[
+            {"code": code, "tilt_degrees": tilt}
+            for code, tilt in BASE_REFLECTIVITY_TILTS.items()
+        ],
+    )
 
 
 """@app.route('/radar_summary/<path:path>')

--- a/app.py
+++ b/app.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
 import json
+from io import BytesIO
+from mimetypes import add_type
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 from dotenv import load_dotenv
-from flask import Flask, jsonify, make_response, render_template, request, url_for
+from flask import Flask, jsonify, make_response, render_template, request, send_file
 from flask_cors import CORS
 
 from run_radar_analysis import Filter
 from services.data_sources import S3DataSource, ThreadDataSource
 from services.data_sources.base import BaseDataSource
+from services.radar_processing import process_level3_bytes
+
+
+add_type("application/javascript", ".js")
 
 load_dotenv()
 
@@ -69,20 +75,51 @@ def radar_files():
 
 # Example:
 #   /radar_filter_q?path=radar_3_data/KMLB_SDUS52_TZ0MCO_202405151912&threshold=23
+def _load_radar_image(path: Path, threshold: Optional[int]):
+    """Render ``path`` at ``threshold`` and return processed content + metadata."""
+
+    if not path.exists():
+        raise FileNotFoundError(path)
+
+    try:
+        processed = process_level3_bytes(path.read_bytes(), threshold)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        raise RuntimeError(str(exc)) from exc
+
+    return processed
+
+
 @app.get("/radar_filter_q")
 def radar_filter_q():
-    """Helper that returns the correct encoded route for the existing filter."""
-    path = request.args.get("path")
-    threshold = request.args.get("threshold", type=int)
-    if not path or threshold is None:
-        return jsonify(error="Provide ?path=<relative file path>&threshold=<int>"), 400
+    """Render a radar image directly as PNG bytes."""
 
-    # Build the exact route to your existing endpoint. url_for handles encoding.
-    route = url_for("subset_radar_file", path=path, filtered_amount=threshold)
-    return jsonify(
-        tip="Open this route to run the filter",
-        route=route
-    )
+    path_value = request.args.get("path")
+    threshold = request.args.get("threshold", type=int)
+
+    if not path_value or threshold is None:
+        return (
+            jsonify(error="Provide ?path=<relative file path>&threshold=<int>"),
+            400,
+        )
+
+    candidate_path = Path(path_value)
+
+    try:
+        processed = _load_radar_image(candidate_path, threshold)
+    except FileNotFoundError:
+        return jsonify(error=f"File not found: {path_value}"), 404
+    except RuntimeError as exc:
+        return jsonify(error=str(exc)), 500
+
+    buffer = BytesIO(processed.content)
+    buffer.seek(0)
+
+    response = send_file(buffer, mimetype=processed.content_type)
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["X-Radar-Source-Path"] = str(candidate_path)
+    if processed.bounds:
+        response.headers["X-Radar-Bounds"] = json.dumps(processed.bounds)
+    return response
 # --- end Brandan additions ---
 
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from io import BytesIO
 from mimetypes import add_type
 from pathlib import Path
@@ -13,7 +14,13 @@ from flask_cors import CORS
 from run_radar_analysis import Filter
 from services.data_sources import S3DataSource, ThreadDataSource
 from services.data_sources.base import BaseDataSource
-from services.radar_processing import process_level3_bytes
+from services import local_cache
+from services.radar_catalog import (
+    BASE_REFLECTIVITY_TILTS,
+    latest_by_radar,
+    sorted_products,
+)
+from services.radar_processing import process_level3_bytes, read_level3_metadata
 
 
 add_type("application/javascript", ".js")
@@ -75,14 +82,14 @@ def radar_files():
 
 # Example:
 #   /radar_filter_q?path=radar_3_data/KMLB_SDUS52_TZ0MCO_202405151912&threshold=23
-def _load_radar_image(path: Path, threshold: Optional[int]):
+def _load_radar_image(path: Path, threshold: Optional[int], view: str):
     """Render ``path`` at ``threshold`` and return processed content + metadata."""
 
     if not path.exists():
         raise FileNotFoundError(path)
 
     try:
-        processed = process_level3_bytes(path.read_bytes(), threshold)
+        processed = process_level3_bytes(path.read_bytes(), threshold, view=view)
     except Exception as exc:  # pragma: no cover - defensive guard
         raise RuntimeError(str(exc)) from exc
 
@@ -95,6 +102,7 @@ def radar_filter_q():
 
     path_value = request.args.get("path")
     threshold = request.args.get("threshold", type=int)
+    view = request.args.get("view", default="combined", type=str)
 
     if not path_value or threshold is None:
         return (
@@ -105,7 +113,7 @@ def radar_filter_q():
     candidate_path = Path(path_value)
 
     try:
-        processed = _load_radar_image(candidate_path, threshold)
+        processed = _load_radar_image(candidate_path, threshold, view)
     except FileNotFoundError:
         return jsonify(error=f"File not found: {path_value}"), 404
     except RuntimeError as exc:
@@ -119,6 +127,8 @@ def radar_filter_q():
     response.headers["X-Radar-Source-Path"] = str(candidate_path)
     if processed.bounds:
         response.headers["X-Radar-Bounds"] = json.dumps(processed.bounds)
+    if processed.metadata:
+        response.headers["X-Radar-Metadata"] = json.dumps(processed.metadata)
     return response
 # --- end Brandan additions ---
 
@@ -152,13 +162,16 @@ def api_file():
     source = request.args.get("source", type=str)
     key = request.args.get("key", type=str)
     threshold = request.args.get("threshold", type=int)
+    view = request.args.get("view", default="combined", type=str)
 
     if not source or not key:
         return jsonify(error="Both 'source' and 'key' parameters are required"), 400
 
     try:
         data_source = get_data_source(source)
-        content, metadata = data_source.get_image_for_key(key, threshold=threshold)
+        content, metadata = data_source.get_image_for_key(
+            key, threshold=threshold, view=view
+        )
     except ValueError as exc:
         return jsonify(error=str(exc)), 400
     except Exception as exc:  # pragma: no cover - defensive guard
@@ -172,8 +185,117 @@ def api_file():
     if bounds:
         response.headers["X-Radar-Bounds"] = json.dumps(bounds)
     response.headers["X-Radar-Key"] = metadata.get("key", key)
+    extras = {k: v for k, v in metadata.items() if k not in {"bounds", "key", "content_type"}}
+    if extras:
+        response.headers["X-Radar-Metadata"] = json.dumps(extras)
 
     return response
+
+
+def _normalise_radar_filter(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    value = value.strip().upper()
+    if not value:
+        return None
+    if len(value) == 3 and not value.startswith("K"):
+        value = f"K{value}"
+    return value
+
+
+@app.get("/api/base_reflectivity/latest")
+def api_latest_base_reflectivity():
+    source = request.args.get("source", type=str)
+    if not source:
+        return jsonify(error="Missing required 'source' parameter"), 400
+
+    prefix = request.args.get("prefix", type=str)
+    radar_filter = _normalise_radar_filter(request.args.get("radar"))
+    include_metadata = request.args.get("include_metadata", default="true", type=str)
+    include_metadata_flag = include_metadata.lower() not in {"false", "0", "no"}
+    limit = request.args.get("limit", default=50, type=int)
+    search_limit = request.args.get("search_limit", default=max(limit * 25, 400), type=int)
+
+    try:
+        data_source = get_data_source(source)
+        keys = data_source.list_keys(prefix=prefix, limit=search_limit)
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 400
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return jsonify(error=str(exc)), 502
+
+    latest = latest_by_radar(keys)
+    radars = []
+
+    for radar_id, products in latest.items():
+        if radar_filter and radar_id != radar_filter:
+            continue
+
+        ordered_products = sorted_products(products)
+        if not ordered_products:
+            continue
+
+        product_entries = []
+        downloaded: Dict[str, bytes] = {}
+        for parsed in ordered_products:
+            try:
+                file_bytes = data_source.get_level3_bytes(parsed.key)
+                downloaded[parsed.key] = file_bytes
+            except Exception as exc:  # pragma: no cover - defensive guard
+                logging.getLogger(__name__).warning(
+                    "Unable to download %s from %s: %s", parsed.key, source, exc
+                )
+            product_entries.append(
+                {
+                    "code": parsed.product_code,
+                    "key": parsed.key,
+                    "timestamp": parsed.timestamp.replace(tzinfo=None).isoformat(),
+                    "tilt_degrees": BASE_REFLECTIVITY_TILTS.get(parsed.product_code),
+                }
+            )
+
+        radar_entry: Dict[str, object] = {
+            "radar_id": radar_id,
+            "raw_radar": ordered_products[0].raw_radar,
+            "products": product_entries,
+        }
+
+        if include_metadata_flag:
+            sample_key = ordered_products[0].key
+            try:
+                file_bytes = downloaded.get(sample_key)
+                if file_bytes is None:
+                    file_bytes = data_source.get_level3_bytes(sample_key)
+                metadata = read_level3_metadata(file_bytes)
+            except Exception:  # pragma: no cover - defensive guard
+                metadata = {}
+            radar_entry.update(metadata)
+
+        radars.append(radar_entry)
+
+    # Prune any cached products older than an hour so the repository only keeps
+    # the freshest scans available to the viewer.
+    try:
+        local_cache.prune(max_age_minutes=60)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logging.getLogger(__name__).warning("Cache pruning failed: %s", exc)
+
+    if include_metadata_flag:
+        radars.sort(key=lambda item: (item.get("location") or item["radar_id"]).upper())
+    else:
+        radars.sort(key=lambda item: item["radar_id"].upper())
+
+    if limit > 0:
+        radars = radars[:limit]
+
+    return jsonify(
+        radars=radars,
+        count=len(radars),
+        products=[
+            {"code": code, "tilt_degrees": tilt}
+            for code, tilt in BASE_REFLECTIVITY_TILTS.items()
+        ],
+    )
 
 
 """@app.route('/radar_summary/<path:path>')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,8 @@ setuptools
 flask
 cartopy
 metpy
+boto3
+requests
+python-dotenv
+Flask-Cors
+pytest

--- a/run_radar_analysis.py
+++ b/run_radar_analysis.py
@@ -1,68 +1,52 @@
-"""
-Module has three main classes. One to filter out the radar image.
-One to produce a csv based on the radar image.
-"""
+"""Legacy filter wrapper maintained for backwards compatibility."""
 
-import cartopy.crs as ccrs
-import matplotlib.gridspec as gridspec
-import matplotlib.pyplot as plt
-import numpy as np
+from __future__ import annotations
 
-from metpy.calc import azimuth_range_to_lat_lon
-from metpy.cbook import get_test_data
-from metpy.io import Level3File
-from metpy.plots import add_metpy_logo, add_timestamp, colortables, USCOUNTIES
-from metpy.units import units
-import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
 
-# Filter class is imported by app.py
-# add other functions to apply to an API call
-class Filter():
-    
-    def __init__(self, file_path):
-        self.radar_data = Level3File(file_path)
-        
-    
-    def filter_dbz(self, filtered_amount):
-        # To do: Remove hard coding and replace with AWS Bucket call
-        radar_data = Level3File("radar_3_data/KMLB_SDUS52_TZ0MCO_202405151912")
+from services.radar_processing import ProcessedImage, process_level3_bytes
 
-        datadict = radar_data.sym_block[0][0]
-        #print (radar_data_dict)
-        data = radar_data.map_data(datadict['data'])
-        data_subset = np.where(data > filtered_amount, data, np.nan)
 
-        spec = gridspec.GridSpec(1, 2)
-        fig = plt.figure(figsize=(15, 8))
-        add_metpy_logo(fig, 190, 85, size='large')
-        ctables = ('NWSStormClearReflectivity', -20, 0.5)  # m/s
+@dataclass
+class FilterResult:
+    """Result returned from the legacy Filter helper."""
 
-        # Grab azimuths and calculate a range based on number of gates,
-        # both with their respective units
-        az = units.Quantity(np.array(datadict['start_az'] + [datadict['end_az'][-1]]), 'degrees')
-        rng = units.Quantity(np.linspace(0, radar_data.max_range, data_subset.shape[-1] + 1), 'kilometers')
+    image_path: Path
+    bounds: Optional[dict]
 
-        # Extract central latitude and longitude from the file
-        cent_lon = radar_data.lon
-        cent_lat = radar_data.lat
 
-        # Convert az,range to x,y
-        xlocs, ylocs = azimuth_range_to_lat_lon(az, rng, cent_lon, cent_lat)
-        ax_rect = gridspec.GridSpec(1,2)[0]
+class Filter:
+    """Compatibility wrapper around :func:`process_level3_bytes`."""
 
-        # Plot the data
-        crs = ccrs.LambertConformal()
-        ax = fig.add_subplot(ax_rect, projection=crs)
-        ax.add_feature(USCOUNTIES, linewidth=0.5)
-        norm, cmap = colortables.get_with_steps(*ctables)
-        ax.pcolormesh(xlocs, ylocs, data_subset, norm=norm, cmap=cmap, transform=ccrs.PlateCarree())
-        ax.set_extent([cent_lon - 0.7, cent_lon + 0.7, cent_lat - 0.7, cent_lat + 0.7])
-        ax.set_aspect('equal', 'datalim')
-        add_timestamp(ax, radar_data.metadata['prod_time'], y=0.02, high_contrast=True)
-        image_name = 'static/radar_filter.jpg'
-        os.makedirs('static', exist_ok=True)
-        plt.savefig(image_name)
+    def __init__(self, file_reference):
+        if isinstance(file_reference, (str, Path)):
+            file_path = Path(file_reference)
+            self._file_bytes = file_path.read_bytes()
+        elif isinstance(file_reference, (bytes, bytearray)):
+            self._file_bytes = bytes(file_reference)
+        else:
+            # file-like object
+            data = file_reference.read()
+            self._file_bytes = data if isinstance(data, bytes) else bytes(data)
 
-        return 'static/radar_filter.jpg'
+    def filter_dbz(self, filtered_amount: Optional[int] = None) -> Path:
+        """Render the radar product and store it under ``static/``."""
+
+        processed: ProcessedImage = process_level3_bytes(self._file_bytes, filtered_amount)
+        output_path = Path("static/radar_filter.png")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(processed.content)
+        return output_path
+
+    def filter_dbz_with_metadata(
+        self, filtered_amount: Optional[int] = None
+    ) -> FilterResult:
+        processed: ProcessedImage = process_level3_bytes(self._file_bytes, filtered_amount)
+        output_path = Path("static/radar_filter.png")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(processed.content)
+        return FilterResult(image_path=output_path, bounds=processed.bounds)
 
     

--- a/scripts/download_latest_level3.py
+++ b/scripts/download_latest_level3.py
@@ -1,0 +1,146 @@
+"""Download the latest Level 3 radar files for a given radar site.
+
+This utility connects to the public NOAA NEXRAD Level 3 S3 bucket and downloads
+any files that are newer than what already exists locally.  By default the
+script targets the KMLB radar site (Melbourne, Florida) and the ``TZ0`` product,
+which corresponds to the "Power of Radar" Level 3 product used by the
+application.
+
+Example
+-------
+>>> python scripts/download_latest_level3.py --target-dir radar_3_data
+"""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, List
+
+import boto3
+from botocore import UNSIGNED
+from botocore.config import Config
+
+BUCKET_NAME = "noaa-nexrad-level3"
+DEFAULT_RADAR = "KMLB"
+DEFAULT_PRODUCT = "TZ0"
+DEFAULT_LOOKBACK_DAYS = 3
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--radar",
+        default=DEFAULT_RADAR,
+        help="Four letter radar station identifier (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--product",
+        default=DEFAULT_PRODUCT,
+        help="Level 3 product code to download (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--target-dir",
+        type=Path,
+        default=Path("radar_3_data"),
+        help="Directory where downloaded files will be stored",
+    )
+    parser.add_argument(
+        "--lookback-days",
+        type=int,
+        default=DEFAULT_LOOKBACK_DAYS,
+        help="Number of days to search for recent files (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--max-downloads",
+        type=int,
+        default=24,
+        help=(
+            "Maximum number of new files to download per execution."
+            " This acts as a safety guard to avoid downloading an"
+            " excessive number of historical products."
+        ),
+    )
+    return parser.parse_args()
+
+
+def build_client():
+    """Return an anonymous S3 client for the public NOAA bucket."""
+    return boto3.client("s3", config=Config(signature_version=UNSIGNED))
+
+
+def list_recent_objects(
+    client, radar: str, product: str, lookback_days: int
+) -> List[dict]:
+    """Return objects sorted from most recent to oldest within the lookback."""
+    now = datetime.now(timezone.utc)
+    objects: List[dict] = []
+    for day_offset in range(lookback_days):
+        day = now - timedelta(days=day_offset)
+        prefix = f"{day:%Y/%m/%d}/{radar}/{product}/"
+        continuation_token = None
+        while True:
+            kwargs = {
+                "Bucket": BUCKET_NAME,
+                "Prefix": prefix,
+                "MaxKeys": 1000,
+            }
+            if continuation_token:
+                kwargs["ContinuationToken"] = continuation_token
+            response = client.list_objects_v2(**kwargs)
+            objects.extend(response.get("Contents", []))
+            if not response.get("IsTruncated"):
+                break
+            continuation_token = response.get("NextContinuationToken")
+    objects.sort(key=lambda obj: obj["LastModified"], reverse=True)
+    return objects
+
+
+def download_new_files(
+    client,
+    objects: Iterable[dict],
+    target_dir: Path,
+    max_downloads: int,
+) -> List[Path]:
+    """Download the first ``max_downloads`` objects that are not stored locally."""
+    downloaded: List[Path] = []
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for obj in objects:
+        key = obj["Key"]
+        filename = Path(key).name
+        destination = target_dir / filename
+        if destination.exists():
+            continue
+        client.download_file(BUCKET_NAME, key, str(destination))
+        downloaded.append(destination)
+        if len(downloaded) >= max_downloads:
+            break
+    return downloaded
+
+
+def main() -> int:
+    args = parse_args()
+    client = build_client()
+    objects = list_recent_objects(client, args.radar, args.product, args.lookback_days)
+    if not objects:
+        print(
+            "No Level 3 objects found for",
+            f"radar={args.radar} product={args.product} in the last {args.lookback_days} days",
+        )
+        return 1
+    downloaded = download_new_files(
+        client,
+        objects,
+        args.target_dir,
+        args.max_downloads,
+    )
+    if downloaded:
+        for path in downloaded:
+            print(f"Downloaded {path}")
+    else:
+        print("No new files to download.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/download_level3_radar.py
+++ b/scripts/download_level3_radar.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Download recent Level III radar files for selected sites."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable, List
+
+try:
+    from metpy.remote import NEXRADLevel3Archive
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+    raise SystemExit(
+        "MetPy is required to download Level III radar data. Install it with 'pip install metpy'."
+    ) from exc
+
+OUTPUT_ROOT = Path(__file__).resolve().parents[1] / "radar_3_data"
+DEFAULT_PRODUCT_CODE = "N0B"
+# Melbourne (KMLB) and Tampa (KTBW)
+SITES = ("KMLB", "KTBW")
+
+
+def _ensure_output_dir(site: str) -> Path:
+    path = OUTPUT_ROOT / site
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _timestamp_range(hours: int = 2) -> tuple[datetime, datetime]:
+    """Return a (start, end) tuple covering the most recent ``hours`` hours."""
+
+    end = datetime.utcnow()
+    start = end - timedelta(hours=hours)
+    return start, end
+
+
+def _save_product(product, destination: Path) -> Path:
+    """Persist a MetPy product handle to ``destination``."""
+
+    handle = product.access()
+    try:
+        payload = handle.read()
+    finally:
+        close = getattr(handle, "close", None)
+        if callable(close):
+            close()
+    destination.write_bytes(payload)
+    return destination
+
+
+def download_recent_products(
+    archive: NEXRADLevel3Archive,
+    site: str,
+    product_code: str = DEFAULT_PRODUCT_CODE,
+    hours: int = 2,
+) -> List[Path]:
+    """Download recent Level III radar files for ``site``.
+
+    Returns a list of paths written beneath :mod:`radar_3_data`.
+    """
+
+    output_dir = _ensure_output_dir(site)
+    start, end = _timestamp_range(hours)
+    products: Iterable = archive.get_range(site, product_code, start, end)
+    saved_paths: List[Path] = []
+
+    for product in products:
+        name = getattr(product, "name", None) or f"{site}_{product_code}_{product.timestamp:%Y%m%d%H%M%S}"
+        destination = output_dir / name
+        if destination.exists():
+            continue
+        saved_paths.append(_save_product(product, destination))
+
+    return saved_paths
+
+
+def main() -> None:
+    archive = NEXRADLevel3Archive()
+    summary: List[str] = []
+
+    for site in SITES:
+        saved = download_recent_products(archive, site)
+        if not saved:
+            summary.append(f"No new {DEFAULT_PRODUCT_CODE} products found for {site}.")
+            continue
+        summary.append(
+            f"Downloaded {len(saved)} {DEFAULT_PRODUCT_CODE} product(s) for {site} into {saved[0].parent}."
+        )
+
+    print("\n".join(summary))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ingest_last_hour.py
+++ b/scripts/ingest_last_hour.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import os
+from typing import List, Tuple
+
+from services.data_sources.s3_source import S3DataSource
+from services.local_cache import store_bytes
+from services.radar_catalog import parse_key
+
+DEFAULT_PRODUCTS = ["N0Q", "N0B"]
+SITES = [
+    s.strip().upper()
+    for s in os.getenv("SITES", "KMLB,KJAX,KMIA,KTBW,KMHX,KLCH,KLIX").split(",")
+    if s.strip()
+]
+MINUTES = int(os.getenv("MINUTES", "60"))
+
+
+def ensure_hourly_folder(now: datetime) -> Path:
+    hour_tag = now.strftime("%Y%m%d%H")
+    target = Path("radar_3_data/hourly") / hour_tag
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def looks_recent(key: str, now: datetime) -> bool:
+    parsed = parse_key(key)
+    if not parsed or not parsed.timestamp:
+        return False
+    return (now - parsed.timestamp).total_seconds() <= MINUTES * 60
+
+
+def main() -> None:
+    now = datetime.now(timezone.utc)
+    hourly_dir = ensure_hourly_folder(now)
+    data_source = S3DataSource()
+
+    keys = data_source.list_keys(prefix=None, limit=3000)
+    filtered: List[str] = []
+    for key in keys:
+        parsed = parse_key(key)
+        if not parsed:
+            continue
+        if (
+            parsed.raw_radar
+            and parsed.raw_radar.upper() in SITES
+            and parsed.product_code in DEFAULT_PRODUCTS
+            and looks_recent(key, now)
+        ):
+            filtered.append(key)
+
+    saved: List[Tuple[str, Path]] = []
+    for key in filtered:
+        payload = data_source.get_level3_bytes(key)
+        store_bytes(key, payload)
+        destination = hourly_dir / Path(key).name
+        destination.write_bytes(payload)
+        saved.append((key, destination))
+
+    print(f"Ingested {len(saved)} files into {hourly_dir} and cached latest/")
+    if not saved:
+        print("Note: zero files matched. Check SITES, S3_BUCKET, and time drift.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke.ps1
+++ b/scripts/smoke.ps1
@@ -1,0 +1,59 @@
+param(
+    [string]$BaseUrl = "http://localhost:5000"
+)
+
+function Invoke-Request {
+    param(
+        [string]$Path
+    )
+    $client = New-Object System.Net.Http.HttpClient
+    $client.BaseAddress = $BaseUrl
+    try {
+        return $client.GetAsync($Path).Result
+    } finally {
+        $client.Dispose()
+    }
+}
+
+function Assert-Status {
+    param(
+        [System.Net.Http.HttpResponseMessage]$Response,
+        [int]$Expected,
+        [string]$Label
+    )
+    if ($Response.StatusCode.value__ -ne $Expected) {
+        throw "$Label expected HTTP $Expected but received $($Response.StatusCode.value__)"
+    }
+    Write-Host "$Label : HTTP $Expected"
+}
+
+$response = Invoke-Request -Path "/health"
+Assert-Status -Response $response -Expected 200 -Label "Health"
+
+$response = Invoke-Request -Path "/static/radar.html"
+Assert-Status -Response $response -Expected 200 -Label "radar.html"
+Write-Host "Content-Type: $($response.Content.Headers.ContentType)"
+
+$response = Invoke-Request -Path "/static/radar.js"
+Assert-Status -Response $response -Expected 200 -Label "radar.js"
+Write-Host "Content-Type: $($response.Content.Headers.ContentType)"
+if ($response.Content.Headers.ContentType.MediaType -notlike "*javascript*") {
+    throw "radar.js missing JavaScript content type"
+}
+
+$response = Invoke-Request -Path "/radar_files"
+Assert-Status -Response $response -Expected 200 -Label "radar_files"
+if ($response.Content.Headers.ContentType.MediaType -ne "application/json") {
+    throw "/radar_files did not return JSON"
+}
+
+$quickPath = "/radar_filter_q?path=radar_3_data/KMLB_SDUS52_TZ0MCO_202405151906.nc&threshold=23"
+$response = Invoke-Request -Path $quickPath
+Assert-Status -Response $response -Expected 200 -Label "radar_filter_q"
+$mediaType = $response.Content.Headers.ContentType.MediaType
+Write-Host "Content-Type: $mediaType"
+if ($mediaType -notlike "image/*") {
+    throw "radar_filter_q did not return image content"
+}
+
+Write-Host "Smoke checks complete."

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer utilities for radar analysis."""

--- a/services/data_sources/__init__.py
+++ b/services/data_sources/__init__.py
@@ -3,9 +3,11 @@
 from .base import BaseDataSource
 from .s3_source import S3DataSource
 from .thread_source import ThreadDataSource
+from .local_source import LocalDataSource
 
 __all__ = [
     "BaseDataSource",
     "S3DataSource",
     "ThreadDataSource",
+    "LocalDataSource",
 ]

--- a/services/data_sources/__init__.py
+++ b/services/data_sources/__init__.py
@@ -1,0 +1,11 @@
+"""Data source abstractions for radar data retrieval."""
+
+from .base import BaseDataSource
+from .s3_source import S3DataSource
+from .thread_source import ThreadDataSource
+
+__all__ = [
+    "BaseDataSource",
+    "S3DataSource",
+    "ThreadDataSource",
+]

--- a/services/data_sources/base.py
+++ b/services/data_sources/base.py
@@ -15,6 +15,10 @@ class BaseDataSource(ABC):
 
     @abstractmethod
     def get_image_for_key(
-        self, key: str, threshold: Optional[int] = None
+        self, key: str, threshold: Optional[int] = None, view: str = "combined"
     ) -> Tuple[bytes, Dict[str, object]]:
         """Return image bytes and metadata for the supplied radar key."""
+
+    @abstractmethod
+    def get_level3_bytes(self, key: str) -> bytes:
+        """Return the raw Level III radar bytes for ``key``."""

--- a/services/data_sources/base.py
+++ b/services/data_sources/base.py
@@ -1,0 +1,20 @@
+"""Abstract base class for radar data sources."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional, Tuple
+
+
+class BaseDataSource(ABC):
+    """Interface for retrieving radar products from a backing store."""
+
+    @abstractmethod
+    def list_keys(self, prefix: Optional[str] = None, limit: int = 50) -> List[str]:
+        """Return radar product keys available from the data source."""
+
+    @abstractmethod
+    def get_image_for_key(
+        self, key: str, threshold: Optional[int] = None
+    ) -> Tuple[bytes, Dict[str, object]]:
+        """Return image bytes and metadata for the supplied radar key."""

--- a/services/data_sources/local_source.py
+++ b/services/data_sources/local_source.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from .base import BaseDataSource
+from ..radar_processing import process_level3_bytes, read_level3_metadata
+
+
+class LocalDataSource(BaseDataSource):
+    """Scan repo-local Level III files under radar_3_data and serve them."""
+
+    def __init__(self, root: Optional[str] = None) -> None:
+        self.root = Path(root or "radar_3_data").resolve()
+
+    def _iter_files(self) -> List[str]:
+        if not self.root.exists():
+            return []
+        keys: List[str] = []
+        for path in self.root.rglob("*"):
+            if path.is_file():
+                keys.append(str(path.relative_to(Path.cwd()).as_posix()))
+        return keys
+
+    def list_keys(self, prefix: Optional[str] = None, limit: int = 50) -> List[str]:
+        keys = self._iter_files()
+        if prefix:
+            prefix_lower = prefix.lower()
+            keys = [key for key in keys if prefix_lower in key.lower()]
+        keys.sort(reverse=True)
+        return keys[: max(0, limit)]
+
+    def get_level3_bytes(self, key: str) -> bytes:
+        path = Path(key)
+        if not path.exists():
+            path = Path.cwd() / key
+        return path.read_bytes()
+
+    def get_image_for_key(
+        self, key: str, threshold: Optional[int] = None, view: str = "combined"
+    ) -> Tuple[bytes, Dict[str, object]]:
+        raw = self.get_level3_bytes(key)
+        processed = process_level3_bytes(raw, threshold, view=view)
+        metadata = read_level3_metadata(raw)
+        metadata.update(processed.metadata)
+        return processed.content, metadata

--- a/services/data_sources/s3_source.py
+++ b/services/data_sources/s3_source.py
@@ -3,12 +3,21 @@
 from __future__ import annotations
 
 import os
+import logging
 from typing import Dict, List, Optional, Tuple
 
 import boto3
 
+from .. import local_cache
+
+try:  # pragma: no cover - optional dependency at runtime
+    from metpy.remote import NEXRADLevel3Archive
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    NEXRADLevel3Archive = None
+
 from .base import BaseDataSource
 from ..radar_processing import process_level3_bytes
+from ..radar_catalog import parse_key
 
 
 class S3DataSource(BaseDataSource):
@@ -21,7 +30,7 @@ class S3DataSource(BaseDataSource):
         client=None,
     ) -> None:
         if bucket is None:
-            bucket = os.getenv("S3_BUCKET")
+            bucket = os.getenv("S3_BUCKET", "noaa-nexrad-level3")
         if not bucket:
             raise ValueError("S3 bucket name is required")
 
@@ -37,6 +46,16 @@ class S3DataSource(BaseDataSource):
             self._client = session.client(
                 "s3", region_name=region or os.getenv("AWS_REGION")
             )
+
+        archive = None
+        if NEXRADLevel3Archive is not None:
+            try:
+                archive = NEXRADLevel3Archive()
+            except Exception as exc:  # pragma: no cover - defensive guard
+                logging.getLogger(__name__).warning(
+                    "Unable to initialise MetPy NEXRAD archive: %s", exc
+                )
+        self._archive = archive
 
     @property
     def client(self):
@@ -71,14 +90,51 @@ class S3DataSource(BaseDataSource):
         return keys[:limit]
 
     def get_image_for_key(
-        self, key: str, threshold: Optional[int] = None
+        self, key: str, threshold: Optional[int] = None, view: str = "combined"
     ) -> Tuple[bytes, Dict[str, object]]:
-        response = self.client.get_object(Bucket=self.bucket, Key=key)
-        file_bytes = response["Body"].read()
-        processed = process_level3_bytes(file_bytes, threshold)
+        file_bytes = self.get_level3_bytes(key)
+        processed = process_level3_bytes(file_bytes, threshold, view=view)
         metadata: Dict[str, object] = {
             "content_type": processed.content_type,
             "bounds": processed.bounds,
             "key": key,
         }
+        metadata.update(processed.metadata)
         return processed.content, metadata
+
+    def get_level3_bytes(self, key: str) -> bytes:
+        cached = local_cache.get_cached_bytes(key)
+        if cached is not None:
+            return cached
+
+        # Prefer MetPy's archive helper when available so we benefit from its
+        # built-in caching and retry behaviour when accessing the public S3
+        # bucket.  Fall back to boto3 if the helper is unavailable or fails.
+        if self._archive is not None:
+            parsed = parse_key(key)
+            if parsed is not None:
+                try:
+                    product = self._archive.get_product(
+                        parsed.raw_radar, parsed.product_code, parsed.timestamp
+                    )
+                    handle = product.access()
+                    try:
+                        payload = handle.read()
+                        local_cache.store_bytes(key, payload)
+                        return payload
+                    finally:
+                        close = getattr(handle, "close", None)
+                        if callable(close):
+                            try:
+                                close()
+                            except Exception:  # pragma: no cover - defensive guard
+                                pass
+                except Exception as exc:  # pragma: no cover - defensive guard
+                    logging.getLogger(__name__).warning(
+                        "MetPy archive fetch failed for %s: %s", key, exc
+                    )
+
+        response = self.client.get_object(Bucket=self.bucket, Key=key)
+        payload = response["Body"].read()
+        local_cache.store_bytes(key, payload)
+        return payload

--- a/services/data_sources/s3_source.py
+++ b/services/data_sources/s3_source.py
@@ -1,0 +1,84 @@
+"""S3-backed radar data source."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Optional, Tuple
+
+import boto3
+
+from .base import BaseDataSource
+from ..radar_processing import process_level3_bytes
+
+
+class S3DataSource(BaseDataSource):
+    """Fetch Level III radar products from an S3 bucket."""
+
+    def __init__(
+        self,
+        bucket: Optional[str] = None,
+        region: Optional[str] = None,
+        client=None,
+    ) -> None:
+        if bucket is None:
+            bucket = os.getenv("S3_BUCKET")
+        if not bucket:
+            raise ValueError("S3 bucket name is required")
+
+        self.bucket = bucket
+        if client is not None:
+            self._client = client
+        else:
+            session_kwargs = {}
+            profile = os.getenv("AWS_PROFILE")
+            if profile:
+                session_kwargs["profile_name"] = profile
+            session = boto3.session.Session(**session_kwargs)
+            self._client = session.client(
+                "s3", region_name=region or os.getenv("AWS_REGION")
+            )
+
+    @property
+    def client(self):
+        return self._client
+
+    def list_keys(self, prefix: Optional[str] = None, limit: int = 50) -> List[str]:
+        if limit <= 0:
+            return []
+
+        kwargs = {"Bucket": self.bucket, "MaxKeys": min(limit, 1000)}
+        if prefix:
+            kwargs["Prefix"] = prefix
+
+        keys: List[str] = []
+        continuation_token: Optional[str] = None
+
+        while len(keys) < limit:
+            if continuation_token:
+                kwargs["ContinuationToken"] = continuation_token
+
+            response = self.client.list_objects_v2(**kwargs)
+            for obj in response.get("Contents", []):
+                keys.append(obj["Key"])
+                if len(keys) >= limit:
+                    break
+
+            if not response.get("IsTruncated") or len(keys) >= limit:
+                break
+
+            continuation_token = response.get("NextContinuationToken")
+
+        return keys[:limit]
+
+    def get_image_for_key(
+        self, key: str, threshold: Optional[int] = None
+    ) -> Tuple[bytes, Dict[str, object]]:
+        response = self.client.get_object(Bucket=self.bucket, Key=key)
+        file_bytes = response["Body"].read()
+        processed = process_level3_bytes(file_bytes, threshold)
+        metadata: Dict[str, object] = {
+            "content_type": processed.content_type,
+            "bounds": processed.bounds,
+            "key": key,
+        }
+        return processed.content, metadata

--- a/services/data_sources/s3_source.py
+++ b/services/data_sources/s3_source.py
@@ -32,7 +32,7 @@ class S3DataSource(BaseDataSource):
         client=None,
     ) -> None:
         if bucket is None:
-            bucket = os.getenv("S3_BUCKET", "noaa-nexrad-level3")
+            bucket = os.getenv("S3_BUCKET", "unidata-nexrad-level3")
         if not bucket:
             raise ValueError("S3 bucket name is required")
 

--- a/services/data_sources/s3_source.py
+++ b/services/data_sources/s3_source.py
@@ -71,14 +71,18 @@ class S3DataSource(BaseDataSource):
         return keys[:limit]
 
     def get_image_for_key(
-        self, key: str, threshold: Optional[int] = None
+        self, key: str, threshold: Optional[int] = None, view: str = "combined"
     ) -> Tuple[bytes, Dict[str, object]]:
-        response = self.client.get_object(Bucket=self.bucket, Key=key)
-        file_bytes = response["Body"].read()
-        processed = process_level3_bytes(file_bytes, threshold)
+        file_bytes = self.get_level3_bytes(key)
+        processed = process_level3_bytes(file_bytes, threshold, view=view)
         metadata: Dict[str, object] = {
             "content_type": processed.content_type,
             "bounds": processed.bounds,
             "key": key,
         }
+        metadata.update(processed.metadata)
         return processed.content, metadata
+
+    def get_level3_bytes(self, key: str) -> bytes:
+        response = self.client.get_object(Bucket=self.bucket, Key=key)
+        return response["Body"].read()

--- a/services/data_sources/s3_source.py
+++ b/services/data_sources/s3_source.py
@@ -7,6 +7,8 @@ import logging
 from typing import Dict, List, Optional, Tuple
 
 import boto3
+from botocore import UNSIGNED
+from botocore.config import Config
 
 from .. import local_cache
 
@@ -43,9 +45,21 @@ class S3DataSource(BaseDataSource):
             if profile:
                 session_kwargs["profile_name"] = profile
             session = boto3.session.Session(**session_kwargs)
-            self._client = session.client(
-                "s3", region_name=region or os.getenv("AWS_REGION")
-            )
+
+            client_kwargs = {}
+            resolved_region = region or os.getenv("AWS_REGION")
+            if resolved_region:
+                client_kwargs["region_name"] = resolved_region
+
+            try:
+                credentials = session.get_credentials()
+            except Exception:  # pragma: no cover - defensive guard
+                credentials = None
+
+            if credentials is None:
+                client_kwargs["config"] = Config(signature_version=UNSIGNED)
+
+            self._client = session.client("s3", **client_kwargs)
 
         archive = None
         if NEXRADLevel3Archive is not None:

--- a/services/data_sources/s3_source.py
+++ b/services/data_sources/s3_source.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import os
+import logging
 from typing import Dict, List, Optional, Tuple
 
 import boto3
 
+try:  # pragma: no cover - optional dependency at runtime
+    from metpy.remote import NEXRADLevel3Archive
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    NEXRADLevel3Archive = None
+
 from .base import BaseDataSource
 from ..radar_processing import process_level3_bytes
+from ..radar_catalog import parse_key
 
 
 class S3DataSource(BaseDataSource):
@@ -37,6 +44,16 @@ class S3DataSource(BaseDataSource):
             self._client = session.client(
                 "s3", region_name=region or os.getenv("AWS_REGION")
             )
+
+        archive = None
+        if NEXRADLevel3Archive is not None:
+            try:
+                archive = NEXRADLevel3Archive()
+            except Exception as exc:  # pragma: no cover - defensive guard
+                logging.getLogger(__name__).warning(
+                    "Unable to initialise MetPy NEXRAD archive: %s", exc
+                )
+        self._archive = archive
 
     @property
     def client(self):
@@ -71,14 +88,43 @@ class S3DataSource(BaseDataSource):
         return keys[:limit]
 
     def get_image_for_key(
-        self, key: str, threshold: Optional[int] = None
+        self, key: str, threshold: Optional[int] = None, view: str = "combined"
     ) -> Tuple[bytes, Dict[str, object]]:
-        response = self.client.get_object(Bucket=self.bucket, Key=key)
-        file_bytes = response["Body"].read()
-        processed = process_level3_bytes(file_bytes, threshold)
+        file_bytes = self.get_level3_bytes(key)
+        processed = process_level3_bytes(file_bytes, threshold, view=view)
         metadata: Dict[str, object] = {
             "content_type": processed.content_type,
             "bounds": processed.bounds,
             "key": key,
         }
+        metadata.update(processed.metadata)
         return processed.content, metadata
+
+    def get_level3_bytes(self, key: str) -> bytes:
+        # Prefer MetPy's archive helper when available so we benefit from its
+        # built-in caching and retry behaviour when accessing the public S3
+        # bucket.  Fall back to boto3 if the helper is unavailable or fails.
+        if self._archive is not None:
+            parsed = parse_key(key)
+            if parsed is not None:
+                try:
+                    product = self._archive.get_product(
+                        parsed.raw_radar, parsed.product_code, parsed.timestamp
+                    )
+                    handle = product.access()
+                    try:
+                        return handle.read()
+                    finally:
+                        close = getattr(handle, "close", None)
+                        if callable(close):
+                            try:
+                                close()
+                            except Exception:  # pragma: no cover - defensive guard
+                                pass
+                except Exception as exc:  # pragma: no cover - defensive guard
+                    logging.getLogger(__name__).warning(
+                        "MetPy archive fetch failed for %s: %s", key, exc
+                    )
+
+        response = self.client.get_object(Bucket=self.bucket, Key=key)
+        return response["Body"].read()

--- a/services/data_sources/thread_source.py
+++ b/services/data_sources/thread_source.py
@@ -27,6 +27,10 @@ class ThreadDataSource(BaseDataSource):
             raise ValueError("Thread server base URL is required")
 
         self.session = session or requests.Session()
+        self.session.headers.setdefault(
+            "User-Agent",
+            "radar-analysis/1.0 (+https://github.com/radar-analysis)",
+        )
         self.base_url = base_url.rstrip("/")
         self.catalog_url = self._build_catalog_url(self.base_url)
         self.file_base_url = self._build_file_base_url(self.base_url)
@@ -68,16 +72,21 @@ class ThreadDataSource(BaseDataSource):
         return datasets
 
     def get_image_for_key(
-        self, key: str, threshold: Optional[int] = None
+        self, key: str, threshold: Optional[int] = None, view: str = "combined"
     ) -> Tuple[bytes, Dict[str, object]]:
-        download_url = urljoin(f"{self.file_base_url}/", key.lstrip("/"))
-        response = self.session.get(download_url, timeout=30)
-        response.raise_for_status()
-        processed = process_level3_bytes(response.content, threshold)
+        file_bytes = self.get_level3_bytes(key)
+        processed = process_level3_bytes(file_bytes, threshold, view=view)
         metadata: Dict[str, object] = {
             "content_type": processed.content_type,
             "bounds": processed.bounds,
             "key": key,
-            "source_url": download_url,
+            "source_url": urljoin(f"{self.file_base_url}/", key.lstrip("/")),
         }
+        metadata.update(processed.metadata)
         return processed.content, metadata
+
+    def get_level3_bytes(self, key: str) -> bytes:
+        download_url = urljoin(f"{self.file_base_url}/", key.lstrip("/"))
+        response = self.session.get(download_url, timeout=30)
+        response.raise_for_status()
+        return response.content

--- a/services/data_sources/thread_source.py
+++ b/services/data_sources/thread_source.py
@@ -1,0 +1,83 @@
+"""THREDDS/NOAA thread server radar data source."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import urljoin
+from xml.etree import ElementTree
+
+import requests
+
+from .base import BaseDataSource
+from ..radar_processing import process_level3_bytes
+
+
+class ThreadDataSource(BaseDataSource):
+    """Retrieve radar products from a THREDDS or NOAA thread server."""
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        if base_url is None:
+            base_url = os.getenv("THREAD_SERVER_URL")
+        if not base_url:
+            raise ValueError("Thread server base URL is required")
+
+        self.session = session or requests.Session()
+        self.base_url = base_url.rstrip("/")
+        self.catalog_url = self._build_catalog_url(self.base_url)
+        self.file_base_url = self._build_file_base_url(self.base_url)
+
+    @staticmethod
+    def _build_catalog_url(base_url: str) -> str:
+        if base_url.endswith("catalog.xml"):
+            return base_url
+        if base_url.endswith("catalog.html"):
+            return base_url[:-4] + "xml"
+        return f"{base_url}/catalog.xml"
+
+    @staticmethod
+    def _build_file_base_url(base_url: str) -> str:
+        if "catalog" in base_url:
+            prefix, *_ = base_url.rsplit("/catalog", 1)
+            return f"{prefix}/fileServer"
+        return base_url
+
+    def list_keys(self, prefix: Optional[str] = None, limit: int = 50) -> List[str]:
+        if limit <= 0:
+            return []
+
+        response = self.session.get(self.catalog_url, timeout=15)
+        response.raise_for_status()
+
+        root = ElementTree.fromstring(response.content)
+        datasets: List[str] = []
+        for dataset in root.findall(".//{*}dataset"):
+            url_path = dataset.attrib.get("urlPath")
+            if not url_path:
+                continue
+            if prefix and not url_path.startswith(prefix):
+                continue
+            datasets.append(url_path)
+            if len(datasets) >= limit:
+                break
+
+        return datasets
+
+    def get_image_for_key(
+        self, key: str, threshold: Optional[int] = None
+    ) -> Tuple[bytes, Dict[str, object]]:
+        download_url = urljoin(f"{self.file_base_url}/", key.lstrip("/"))
+        response = self.session.get(download_url, timeout=30)
+        response.raise_for_status()
+        processed = process_level3_bytes(response.content, threshold)
+        metadata: Dict[str, object] = {
+            "content_type": processed.content_type,
+            "bounds": processed.bounds,
+            "key": key,
+            "source_url": download_url,
+        }
+        return processed.content, metadata

--- a/services/data_sources/thread_source.py
+++ b/services/data_sources/thread_source.py
@@ -9,6 +9,8 @@ from xml.etree import ElementTree
 
 import requests
 
+from .. import local_cache
+
 from .base import BaseDataSource
 from ..radar_processing import process_level3_bytes
 
@@ -27,6 +29,10 @@ class ThreadDataSource(BaseDataSource):
             raise ValueError("Thread server base URL is required")
 
         self.session = session or requests.Session()
+        self.session.headers.setdefault(
+            "User-Agent",
+            "radar-analysis/1.0 (+https://github.com/radar-analysis)",
+        )
         self.base_url = base_url.rstrip("/")
         self.catalog_url = self._build_catalog_url(self.base_url)
         self.file_base_url = self._build_file_base_url(self.base_url)
@@ -68,16 +74,27 @@ class ThreadDataSource(BaseDataSource):
         return datasets
 
     def get_image_for_key(
-        self, key: str, threshold: Optional[int] = None
+        self, key: str, threshold: Optional[int] = None, view: str = "combined"
     ) -> Tuple[bytes, Dict[str, object]]:
-        download_url = urljoin(f"{self.file_base_url}/", key.lstrip("/"))
-        response = self.session.get(download_url, timeout=30)
-        response.raise_for_status()
-        processed = process_level3_bytes(response.content, threshold)
+        file_bytes = self.get_level3_bytes(key)
+        processed = process_level3_bytes(file_bytes, threshold, view=view)
         metadata: Dict[str, object] = {
             "content_type": processed.content_type,
             "bounds": processed.bounds,
             "key": key,
-            "source_url": download_url,
+            "source_url": urljoin(f"{self.file_base_url}/", key.lstrip("/")),
         }
+        metadata.update(processed.metadata)
         return processed.content, metadata
+
+    def get_level3_bytes(self, key: str) -> bytes:
+        cached = local_cache.get_cached_bytes(key)
+        if cached is not None:
+            return cached
+
+        download_url = urljoin(f"{self.file_base_url}/", key.lstrip("/"))
+        response = self.session.get(download_url, timeout=30)
+        response.raise_for_status()
+        payload = response.content
+        local_cache.store_bytes(key, payload)
+        return payload

--- a/services/data_sources/thread_source.py
+++ b/services/data_sources/thread_source.py
@@ -68,16 +68,21 @@ class ThreadDataSource(BaseDataSource):
         return datasets
 
     def get_image_for_key(
-        self, key: str, threshold: Optional[int] = None
+        self, key: str, threshold: Optional[int] = None, view: str = "combined"
     ) -> Tuple[bytes, Dict[str, object]]:
-        download_url = urljoin(f"{self.file_base_url}/", key.lstrip("/"))
-        response = self.session.get(download_url, timeout=30)
-        response.raise_for_status()
-        processed = process_level3_bytes(response.content, threshold)
+        file_bytes = self.get_level3_bytes(key)
+        processed = process_level3_bytes(file_bytes, threshold, view=view)
         metadata: Dict[str, object] = {
             "content_type": processed.content_type,
             "bounds": processed.bounds,
             "key": key,
-            "source_url": download_url,
+            "source_url": urljoin(f"{self.file_base_url}/", key.lstrip("/")),
         }
+        metadata.update(processed.metadata)
         return processed.content, metadata
+
+    def get_level3_bytes(self, key: str) -> bytes:
+        download_url = urljoin(f"{self.file_base_url}/", key.lstrip("/"))
+        response = self.session.get(download_url, timeout=30)
+        response.raise_for_status()
+        return response.content

--- a/services/local_cache.py
+++ b/services/local_cache.py
@@ -1,0 +1,82 @@
+"""Local caching helpers for radar products."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+_CACHE_ROOT = Path("radar_3_data/latest")
+
+
+def _normalise_key(key: str) -> Path:
+    """Return a filesystem-safe relative path for ``key``."""
+
+    # ``key`` values are typically S3 object keys (which already use forward
+    # slashes), so we can rely on :class:`pathlib.Path` to split them
+    # appropriately while preserving any nested directory structure.
+    return Path(key.lstrip("/"))
+
+
+def cache_path(key: str) -> Path:
+    """Return the path on disk that should hold ``key``'s payload."""
+
+    return _CACHE_ROOT / _normalise_key(key)
+
+
+def get_cached_bytes(key: str) -> Optional[bytes]:
+    """Return cached bytes for ``key`` if present on disk."""
+
+    path = cache_path(key)
+    if not path.exists():
+        return None
+    try:
+        return path.read_bytes()
+    except OSError:
+        return None
+
+
+def store_bytes(key: str, payload: bytes) -> Path:
+    """Persist ``payload`` for ``key`` under the cache directory."""
+
+    path = cache_path(key)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+    # Touch the file so the modification time reflects the most recent fetch.
+    path.touch()
+    return path
+
+
+def prune(max_age_minutes: int = 60) -> None:
+    """Delete cached radar products older than ``max_age_minutes``."""
+
+    if max_age_minutes <= 0:
+        return
+    cutoff = datetime.utcnow() - timedelta(minutes=max_age_minutes)
+    if not _CACHE_ROOT.exists():
+        return
+
+    for path in list(_CACHE_ROOT.rglob("*")):
+        if not path.is_file():
+            continue
+        try:
+            mtime = datetime.utcfromtimestamp(path.stat().st_mtime)
+        except OSError:
+            continue
+        if mtime < cutoff:
+            try:
+                path.unlink()
+            except OSError:
+                continue
+            _cleanup_empty_parents(path.parent)
+
+
+def _cleanup_empty_parents(directory: Path) -> None:
+    """Remove empty parent directories up to the cache root."""
+
+    while directory != _CACHE_ROOT:
+        try:
+            directory.rmdir()
+        except OSError:
+            break
+        directory = directory.parent

--- a/services/radar_catalog.py
+++ b/services/radar_catalog.py
@@ -1,0 +1,134 @@
+"""Utilities for organising radar product inventories."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional
+
+
+BASE_REFLECTIVITY_TILTS: Mapping[str, float] = {
+    "N0B": 0.5,
+    "N1B": 1.5,
+    "N2B": 2.4,
+    "N3B": 3.4,
+    "N0R": 0.5,
+    "N1R": 1.5,
+    "N2R": 2.4,
+    "N3R": 3.4,
+    "N0Q": 0.5,
+    "N1Q": 1.5,
+    "N2Q": 2.4,
+    "N3Q": 3.4,
+    "TR0": 0.5,
+    "TR1": 1.5,
+    "TR2": 2.4,
+    "TR3": 3.4,
+    "TZ0": 0.5,
+    "TZ1": 1.5,
+    "TZ2": 2.4,
+    "TZ3": 3.4,
+}
+
+
+@dataclass
+class ParsedKey:
+    key: str
+    radar_id: str
+    raw_radar: str
+    product_code: str
+    timestamp: datetime
+
+
+def _strip_extensions(value: str) -> str:
+    base = value
+    while True:
+        stem, ext = Path(base).stem, Path(base).suffix
+        if not ext:
+            return stem
+        base = stem
+
+
+def _normalise_radar_id(raw: str) -> str:
+    cleaned = raw.upper()
+    if len(cleaned) == 3:
+        return f"K{cleaned}"
+    return cleaned
+
+
+def _parse_timestamp(tokens: List[str]) -> Optional[datetime]:
+    for token in reversed(tokens):
+        token = token.strip()
+        for fmt in ("%Y%m%d%H%M%S", "%Y%m%d%H%M", "%Y_%m_%d_%H_%M_%S"):
+            try:
+                return datetime.strptime(token, fmt)
+            except ValueError:
+                continue
+    return None
+
+
+def parse_key(key: str) -> Optional[ParsedKey]:
+    """Attempt to extract useful metadata from a radar product key."""
+
+    if not key:
+        return None
+
+    parts = _strip_extensions(Path(key).name).split("_")
+    if not parts:
+        return None
+
+    raw_radar = parts[0].upper()
+    radar_id = _normalise_radar_id(raw_radar)
+
+    product_code = None
+    for part in parts[1:]:
+        upper = part.upper()
+        for candidate in BASE_REFLECTIVITY_TILTS:
+            if upper.startswith(candidate):
+                product_code = candidate
+                break
+        if product_code:
+            break
+
+    if product_code is None:
+        return None
+
+    timestamp = _parse_timestamp(parts)
+    if timestamp is None:
+        return None
+
+    return ParsedKey(key=key, radar_id=radar_id, raw_radar=raw_radar, product_code=product_code, timestamp=timestamp)
+
+
+def latest_by_radar(keys: Iterable[str]) -> Dict[str, Dict[str, ParsedKey]]:
+    """Group keys by radar + product and keep the newest per product."""
+
+    results: Dict[str, Dict[str, ParsedKey]] = {}
+    for key in keys:
+        parsed = parse_key(key)
+        if not parsed:
+            continue
+
+        radar_bucket = results.setdefault(parsed.radar_id, {})
+        current = radar_bucket.get(parsed.product_code)
+        if current is None or parsed.timestamp > current.timestamp:
+            radar_bucket[parsed.product_code] = parsed
+
+    return {radar: products for radar, products in results.items() if products}
+
+
+def sorted_products(products: Mapping[str, ParsedKey]) -> List[ParsedKey]:
+    """Return base reflectivity products in tilt order."""
+
+    ordered: List[ParsedKey] = []
+    for code in ("TZ0", "TR0", "N0B", "N0Q", "N0R", "TZ1", "TR1", "N1B", "N1Q", "N1R", "TZ2", "TR2", "N2B", "N2Q", "N2R", "TZ3", "TR3", "N3B", "N3Q", "N3R"):
+        if code in products:
+            ordered.append(products[code])
+    # Append any remaining codes (unexpected ordering) at the end.
+    seen = {item.product_code for item in ordered}
+    for parsed in sorted(products.values(), key=lambda item: item.timestamp, reverse=True):
+        if parsed.product_code not in seen:
+            ordered.append(parsed)
+            seen.add(parsed.product_code)
+    return ordered

--- a/services/radar_processing.py
+++ b/services/radar_processing.py
@@ -1,0 +1,121 @@
+"""Utilities for converting NEXRAD Level III files into imagery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Dict, Optional
+
+import matplotlib.gridspec as gridspec
+import matplotlib.pyplot as plt
+import numpy as np
+from cartopy import crs as ccrs
+from metpy.calc import azimuth_range_to_lat_lon
+from metpy.io import Level3File
+from metpy.plots import USCOUNTIES, add_metpy_logo, add_timestamp, colortables
+from metpy.units import units
+
+
+@dataclass
+class ProcessedImage:
+    """Container for processed radar image data."""
+
+    content: bytes
+    content_type: str
+    bounds: Optional[Dict[str, float]]
+
+
+def _compute_bounds(
+    level3: Level3File, datadict, mapped_data: np.ndarray
+) -> Optional[Dict[str, float]]:
+    """Compute a geographic bounding box for the product if possible."""
+
+    try:
+        az = units.Quantity(
+            np.array(datadict["start_az"] + [datadict["end_az"][-1]]), "degrees"
+        )
+        gate_count = mapped_data.shape[-1]
+        rng = units.Quantity(
+            np.linspace(0, level3.max_range, gate_count + 1), "kilometers"
+        )
+        lons, lats = azimuth_range_to_lat_lon(az, rng, level3.lon, level3.lat)
+        min_lat = float(np.nanmin(lats))
+        max_lat = float(np.nanmax(lats))
+        min_lon = float(np.nanmin(lons))
+        max_lon = float(np.nanmax(lons))
+    except Exception:  # pragma: no cover - defensive guard
+        return None
+
+    if any(np.isnan(v) for v in (min_lat, max_lat, min_lon, max_lon)):
+        return None
+
+    return {
+        "min_lat": min_lat,
+        "max_lat": max_lat,
+        "min_lon": min_lon,
+        "max_lon": max_lon,
+        "center_lat": float(level3.lat),
+        "center_lon": float(level3.lon),
+    }
+
+
+def process_level3_bytes(
+    file_bytes: bytes, threshold: Optional[int] = None
+) -> ProcessedImage:
+    """Render a Level III radar product into a PNG image."""
+
+    buffer = BytesIO(file_bytes)
+    radar_data = Level3File(buffer)
+    datadict = radar_data.sym_block[0][0]
+    mapped_data = radar_data.map_data(datadict["data"])
+
+    if threshold is not None:
+        data_subset = np.where(mapped_data >= threshold, mapped_data, np.nan)
+    else:
+        data_subset = mapped_data
+
+    spec = gridspec.GridSpec(1, 1)
+    fig = plt.figure(figsize=(10, 8))
+    add_metpy_logo(fig, 160, 85, size="large")
+    ctables = ("NWSStormClearReflectivity", -20, 0.5)
+
+    az = units.Quantity(
+        np.array(datadict["start_az"] + [datadict["end_az"][-1]]), "degrees"
+    )
+    rng = units.Quantity(
+        np.linspace(0, radar_data.max_range, data_subset.shape[-1] + 1), "kilometers"
+    )
+
+    lon_grid, lat_grid = azimuth_range_to_lat_lon(az, rng, radar_data.lon, radar_data.lat)
+
+    ax_rect = spec[0]
+    crs = ccrs.LambertConformal()
+    ax = fig.add_subplot(ax_rect, projection=crs)
+    ax.add_feature(USCOUNTIES, linewidth=0.5)
+    norm, cmap = colortables.get_with_steps(*ctables)
+    ax.pcolormesh(
+        lon_grid,
+        lat_grid,
+        data_subset,
+        norm=norm,
+        cmap=cmap,
+        transform=ccrs.PlateCarree(),
+    )
+    ax.set_extent(
+        [radar_data.lon - 0.7, radar_data.lon + 0.7, radar_data.lat - 0.7, radar_data.lat + 0.7]
+    )
+    ax.set_aspect("equal", "datalim")
+    add_timestamp(ax, radar_data.metadata["prod_time"], y=0.02, high_contrast=True)
+
+    output = BytesIO()
+    fig.savefig(output, format="png", bbox_inches="tight")
+    plt.close(fig)
+    output.seek(0)
+
+    bounds = _compute_bounds(radar_data, datadict, mapped_data)
+
+    return ProcessedImage(
+        content=output.read(),
+        content_type="image/png",
+        bounds=bounds,
+    )

--- a/services/radar_processing.py
+++ b/services/radar_processing.py
@@ -3,16 +3,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from io import BytesIO
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import numpy as np
 from cartopy import crs as ccrs
+from cartopy import feature as cfeature
 from metpy.calc import azimuth_range_to_lat_lon
 from metpy.io import Level3File
-from metpy.plots import USCOUNTIES, add_metpy_logo, add_timestamp, colortables
+from metpy.plots import USCOUNTIES, add_timestamp, colortables
 from metpy.units import units
 
 
@@ -23,6 +25,179 @@ class ProcessedImage:
     content: bytes
     content_type: str
     bounds: Optional[Dict[str, float]]
+    metadata: Dict[str, object]
+
+
+def _strip_whitespace(value: str) -> str:
+    return " ".join(value.split())
+
+
+def _parse_location(raw_location: Optional[str]) -> Tuple[Optional[str], Optional[str], str]:
+    """Return ``(city, state, display_name)`` from a Level 3 location string."""
+
+    if not raw_location:
+        return None, None, "Unknown Location"
+
+    cleaned = _strip_whitespace(str(raw_location)).strip()
+    if not cleaned:
+        return None, None, "Unknown Location"
+
+    # Many products use ``CITY ST US`` formatting, others ``City, ST``.
+    if "," in cleaned:
+        city_part, remainder = [part.strip() for part in cleaned.split(",", 1)]
+        state_part = remainder.split()[0] if remainder else ""
+    else:
+        parts = cleaned.split()
+        city_part = " ".join(parts[:-1]) if len(parts) > 1 else cleaned
+        state_part = parts[-1] if len(parts) > 1 else ""
+
+    city = city_part.title() if city_part else None
+    state = state_part.upper() if state_part else None
+
+    if city and state:
+        display = f"{city}, {state}"
+    elif city:
+        display = city
+    elif state:
+        display = state
+    else:
+        display = cleaned.title()
+
+    return city, state, display
+
+
+_STATE_EXTENTS = {
+    "AL": (-88.6, -84.7, 30.1, 35.1),
+    "AK": (-170.0, -129.0, 51.0, 71.5),
+    "AR": (-94.6, -89.6, 33.0, 36.6),
+    "AZ": (-115.0, -108.8, 31.0, 37.1),
+    "CA": (-125.0, -113.7, 32.0, 42.1),
+    "CO": (-109.1, -101.9, 36.8, 41.2),
+    "CT": (-73.9, -71.7, 40.9, 42.1),
+    "DC": (-77.3, -76.8, 38.7, 39.1),
+    "DE": (-75.9, -75.0, 38.4, 39.9),
+    "FL": (-88.1, -79.8, 24.3, 31.2),
+    "GA": (-85.6, -80.7, 30.3, 35.1),
+    "HI": (-161.1, -154.7, 18.8, 22.4),
+    "IA": (-96.7, -90.1, 40.2, 43.6),
+    "ID": (-117.3, -110.6, 41.9, 49.1),
+    "IL": (-91.6, -87.0, 36.8, 42.5),
+    "IN": (-88.2, -84.7, 37.7, 41.8),
+    "KS": (-102.1, -94.6, 36.8, 40.1),
+    "KY": (-89.6, -81.8, 36.3, 39.3),
+    "LA": (-94.1, -88.7, 28.9, 33.1),
+    "MA": (-73.6, -69.8, 41.2, 42.9),
+    "MD": (-79.5, -75.0, 37.9, 39.8),
+    "ME": (-71.1, -66.8, 43.0, 47.5),
+    "MI": (-90.5, -82.1, 41.6, 48.3),
+    "MN": (-97.3, -89.5, 43.5, 49.4),
+    "MO": (-95.8, -89.1, 35.9, 40.7),
+    "MS": (-91.7, -88.1, 30.1, 35.1),
+    "MT": (-116.1, -104.0, 44.2, 49.2),
+    "NC": (-84.4, -75.4, 33.6, 36.6),
+    "ND": (-104.2, -96.4, 45.8, 49.0),
+    "NE": (-104.1, -95.0, 39.9, 43.1),
+    "NH": (-72.6, -70.6, 42.6, 45.3),
+    "NJ": (-75.6, -73.8, 38.9, 41.4),
+    "NM": (-109.1, -103.0, 31.1, 37.1),
+    "NV": (-120.1, -114.0, 35.0, 42.3),
+    "NY": (-80.0, -71.5, 40.4, 45.2),
+    "OH": (-84.9, -80.5, 38.1, 42.3),
+    "OK": (-103.2, -94.4, 33.4, 37.3),
+    "OR": (-124.8, -116.5, 41.8, 46.3),
+    "PA": (-80.6, -74.7, 39.7, 42.5),
+    "PR": (-67.3, -65.1, 17.8, 18.6),
+    "RI": (-71.9, -71.0, 41.1, 42.1),
+    "SC": (-83.4, -78.3, 32.0, 35.3),
+    "SD": (-104.1, -96.3, 42.5, 45.9),
+    "TN": (-90.5, -81.6, 34.9, 36.9),
+    "TX": (-106.7, -93.4, 25.5, 36.6),
+    "UT": (-114.1, -109.0, 36.8, 42.2),
+    "VA": (-83.7, -75.2, 36.4, 39.5),
+    "VT": (-73.5, -71.4, 42.7, 45.1),
+    "WA": (-124.9, -116.9, 45.5, 49.1),
+    "WI": (-92.9, -86.2, 42.4, 47.3),
+    "WV": (-82.7, -77.7, 37.1, 40.6),
+    "WY": (-111.1, -104.1, 40.9, 45.1),
+}
+
+
+def _state_extent(state: Optional[str]) -> Optional[Tuple[float, float, float, float]]:
+    if not state:
+        return None
+    return _STATE_EXTENTS.get(state.upper())
+
+
+def _normalise_timestamp(value) -> Optional[str]:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value.replace(tzinfo=None).isoformat()
+    text = str(value).strip()
+    for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y%m%d%H%M%S", "%Y%m%d%H%M"):
+        try:
+            parsed = datetime.strptime(text, fmt)
+            return parsed.isoformat()
+        except ValueError:
+            continue
+    return text
+
+
+def extract_basic_metadata(level3: Level3File) -> Dict[str, object]:
+    """Extract useful metadata for downstream consumers."""
+
+    metadata_dict = getattr(level3, "metadata", {}) or {}
+
+    radar_id = (
+        metadata_dict.get("icao")
+        or getattr(level3, "icao", None)
+        or metadata_dict.get("radar_id")
+    )
+    if radar_id:
+        radar_id = str(radar_id).upper()
+        if len(radar_id) == 3:
+            radar_id = f"K{radar_id}"
+
+    location_raw = metadata_dict.get("radar_location")
+    city, state, display_location = _parse_location(location_raw)
+
+    product_name = metadata_dict.get("prod_desc") or metadata_dict.get("prod_name") or ""
+
+    elevation = None
+    elevation = (
+        metadata_dict.get("elev_angle")
+        or metadata_dict.get("elevation_angle")
+        or metadata_dict.get("elev")
+    )
+    try:
+        elevation_degrees = float(elevation) if elevation is not None else None
+    except (TypeError, ValueError):
+        elevation_degrees = None
+
+    title_parts = []
+    if radar_id:
+        title_parts.append(radar_id)
+    if display_location:
+        title_parts.append(display_location)
+    if product_name:
+        title_parts.append(product_name)
+    if elevation_degrees is not None:
+        title_parts.append(f"{elevation_degrees:.1f}° Tilt")
+    title = " • ".join(title_parts)
+
+    return {
+        "radar_id": radar_id,
+        "city": city,
+        "state": state,
+        "location": display_location,
+        "product_name": product_name,
+        "elevation_degrees": elevation_degrees,
+        "title": title,
+        "product_time": _normalise_timestamp(metadata_dict.get("prod_time")),
+        "volume_time": _normalise_timestamp(metadata_dict.get("vol_time")),
+        "radar_lat": float(level3.lat),
+        "radar_lon": float(level3.lon),
+    }
 
 
 def _compute_bounds(
@@ -60,9 +235,13 @@ def _compute_bounds(
 
 
 def process_level3_bytes(
-    file_bytes: bytes, threshold: Optional[int] = None
+    file_bytes: bytes, threshold: Optional[int] = None, view: str = "combined"
 ) -> ProcessedImage:
     """Render a Level III radar product into a PNG image."""
+
+    view = (view or "combined").lower()
+    if view not in {"combined", "overview", "zoom"}:
+        raise ValueError(f"Unsupported view '{view}'")
 
     buffer = BytesIO(file_bytes)
     radar_data = Level3File(buffer)
@@ -74,9 +253,8 @@ def process_level3_bytes(
     else:
         data_subset = mapped_data
 
-    spec = gridspec.GridSpec(1, 1)
-    fig = plt.figure(figsize=(10, 8))
-    add_metpy_logo(fig, 160, 85, size="large")
+    metadata = extract_basic_metadata(radar_data)
+
     ctables = ("NWSStormClearReflectivity", -20, 0.5)
 
     az = units.Quantity(
@@ -88,34 +266,102 @@ def process_level3_bytes(
 
     lon_grid, lat_grid = azimuth_range_to_lat_lon(az, rng, radar_data.lon, radar_data.lat)
 
-    ax_rect = spec[0]
-    crs = ccrs.LambertConformal()
-    ax = fig.add_subplot(ax_rect, projection=crs)
-    ax.add_feature(USCOUNTIES, linewidth=0.5)
+    if view == "combined":
+        fig = plt.figure(figsize=(16, 8))
+        spec = gridspec.GridSpec(1, 2, width_ratios=[1.05, 1.0])
+        axes = [
+            fig.add_subplot(spec[0], projection=ccrs.LambertConformal()),
+            fig.add_subplot(spec[1], projection=ccrs.LambertConformal()),
+        ]
+    else:
+        fig = plt.figure(figsize=(10, 8))
+        spec = gridspec.GridSpec(1, 1)
+        axes = [fig.add_subplot(spec[0], projection=ccrs.LambertConformal())]
+
     norm, cmap = colortables.get_with_steps(*ctables)
-    ax.pcolormesh(
-        lon_grid,
-        lat_grid,
-        data_subset,
-        norm=norm,
-        cmap=cmap,
-        transform=ccrs.PlateCarree(),
+
+    overview_extent = _state_extent(metadata.get("state"))
+    if overview_extent is None:
+        overview_extent = (
+            metadata["radar_lon"] - 7.0,
+            metadata["radar_lon"] + 7.0,
+            metadata["radar_lat"] - 5.0,
+            metadata["radar_lat"] + 5.0,
+        )
+
+    zoom_extent = (
+        metadata["radar_lon"] - 0.75,
+        metadata["radar_lon"] + 0.75,
+        metadata["radar_lat"] - 0.75,
+        metadata["radar_lat"] + 0.75,
     )
-    ax.set_extent(
-        [radar_data.lon - 0.7, radar_data.lon + 0.7, radar_data.lat - 0.7, radar_data.lat + 0.7]
-    )
-    ax.set_aspect("equal", "datalim")
-    add_timestamp(ax, radar_data.metadata["prod_time"], y=0.02, high_contrast=True)
+
+    for idx, ax in enumerate(axes):
+        ax.add_feature(cfeature.STATES.with_scale("50m"), linewidth=0.5, edgecolor="#666")
+        ax.add_feature(USCOUNTIES, linewidth=0.5)
+        ax.add_feature(cfeature.COASTLINE.with_scale("110m"), linewidth=0.6)
+        ax.add_feature(cfeature.BORDERS.with_scale("110m"), linewidth=0.4)
+        ax.pcolormesh(
+            lon_grid,
+            lat_grid,
+            data_subset,
+            norm=norm,
+            cmap=cmap,
+            transform=ccrs.PlateCarree(),
+        )
+        ax.plot(
+            metadata["radar_lon"],
+            metadata["radar_lat"],
+            marker="o",
+            markersize=6,
+            color="white",
+            markeredgecolor="black",
+            transform=ccrs.PlateCarree(),
+        )
+        if view == "overview" or (view == "combined" and idx == 0):
+            ax.set_extent(overview_extent)
+            ax.set_title("State Overview", fontsize=11)
+        else:
+            ax.set_extent(zoom_extent)
+            ax.set_title("Local Zoom", fontsize=11)
+        ax.set_aspect("equal", "datalim")
+
+    timestamp_value = radar_data.metadata.get("prod_time") if radar_data.metadata else None
+    if timestamp_value:
+        add_timestamp(
+            axes[-1],
+            timestamp_value,
+            y=0.02,
+            high_contrast=True,
+        )
+
+    title = metadata.get("title") or "Radar Product"
+    fig.suptitle(title, fontsize=16, fontweight="bold")
 
     output = BytesIO()
-    fig.savefig(output, format="png", bbox_inches="tight")
+    fig.savefig(output, format="png", bbox_inches="tight", dpi=150)
     plt.close(fig)
     output.seek(0)
 
     bounds = _compute_bounds(radar_data, datadict, mapped_data)
 
+    metadata.update({
+        "view": view,
+        "overview_extent": overview_extent,
+        "zoom_extent": zoom_extent,
+    })
+
     return ProcessedImage(
         content=output.read(),
         content_type="image/png",
         bounds=bounds,
+        metadata=metadata,
     )
+
+
+def read_level3_metadata(file_bytes: bytes) -> Dict[str, object]:
+    """Parse metadata from Level III bytes without rendering imagery."""
+
+    buffer = BytesIO(file_bytes)
+    level3 = Level3File(buffer)
+    return extract_basic_metadata(level3)

--- a/static/js/radar.js
+++ b/static/js/radar.js
@@ -1,0 +1,260 @@
+(() => {
+  const state = {
+    currentSource: 's3',
+    currentKey: null,
+    threshold: 23,
+    overlayEnabled: true,
+    map: null,
+    overlay: null,
+    lastObjectUrl: null,
+  };
+
+  const sourceSelect = document.getElementById('sourceSelect');
+  const prefixInput = document.getElementById('prefixInput');
+  const limitInput = document.getElementById('limitInput');
+  const thresholdSlider = document.getElementById('thresholdSlider');
+  const thresholdInput = document.getElementById('thresholdInput');
+  const listBtn = document.getElementById('listBtn');
+  const fileList = document.getElementById('fileList');
+  const overlayToggle = document.getElementById('overlayToggle');
+  const radarImage = document.getElementById('radarImage');
+  const mapContainer = document.getElementById('map');
+  const quickTestBtn = document.getElementById('quickTest');
+  const statusBar = document.getElementById('status');
+
+  function showStatus(message, isError = false) {
+    if (!message) {
+      statusBar.classList.add('hidden');
+      statusBar.textContent = '';
+      return;
+    }
+    statusBar.textContent = message;
+    statusBar.classList.toggle('hidden', false);
+    statusBar.style.background = isError ? '#fee2e2' : '#fff7ed';
+    statusBar.style.borderTopColor = isError ? '#fecaca' : '#fcd9bd';
+    statusBar.style.color = isError ? '#991b1b' : '#9a3412';
+  }
+
+  function revokeObjectUrl() {
+    if (state.lastObjectUrl) {
+      URL.revokeObjectURL(state.lastObjectUrl);
+      state.lastObjectUrl = null;
+    }
+  }
+
+  function clearActiveListItem() {
+    fileList.querySelectorAll('li').forEach((li) => li.classList.remove('active'));
+  }
+
+  function setActiveListItem(key) {
+    clearActiveListItem();
+    const match = Array.from(fileList.querySelectorAll('li')).find((li) => li.dataset.key === key);
+    if (match) {
+      match.classList.add('active');
+      match.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }
+
+  function ensureMap() {
+    if (!state.map) {
+      state.map = L.map(mapContainer).setView([27.6648, -81.5158], 6);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; OpenStreetMap contributors',
+      }).addTo(state.map);
+    }
+    return state.map;
+  }
+
+  function setDisplayMode(boundsAvailable) {
+    const shouldShowMap = state.overlayEnabled && boundsAvailable;
+    mapContainer.classList.toggle('hidden', !shouldShowMap);
+    radarImage.classList.toggle('hidden', shouldShowMap);
+    if (shouldShowMap) {
+      ensureMap();
+      setTimeout(() => state.map && state.map.invalidateSize(), 50);
+    }
+  }
+
+  function renderOverlay(imageUrl, bounds) {
+    const map = ensureMap();
+    if (state.overlay) {
+      state.overlay.remove();
+      state.overlay = null;
+    }
+
+    if (!bounds) {
+      setDisplayMode(false);
+      radarImage.src = imageUrl;
+      radarImage.alt = 'Radar product';
+      return;
+    }
+
+    const leafletBounds = [
+      [bounds.min_lat, bounds.min_lon],
+      [bounds.max_lat, bounds.max_lon],
+    ];
+
+    state.overlay = L.imageOverlay(imageUrl, leafletBounds, { opacity: 0.85 });
+    state.overlay.addTo(map);
+    map.fitBounds(leafletBounds);
+    setDisplayMode(true);
+  }
+
+  async function loadImage(key, options = {}) {
+    if (!key) {
+      return;
+    }
+
+    state.currentKey = key;
+    if (!options.skipListHighlight) {
+      setActiveListItem(key);
+    }
+
+    const threshold = Number(thresholdInput.value);
+    state.threshold = threshold;
+
+    const params = new URLSearchParams({
+      source: state.currentSource,
+      key,
+    });
+    if (!Number.isNaN(threshold)) {
+      params.set('threshold', String(threshold));
+    }
+
+    showStatus('Fetching radar image…');
+    revokeObjectUrl();
+
+    try {
+      const response = await fetch(`/api/file?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error(`Server responded with ${response.status}`);
+      }
+      const boundsHeader = response.headers.get('X-Radar-Bounds');
+      const bounds = boundsHeader ? JSON.parse(boundsHeader) : null;
+      const blob = await response.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      state.lastObjectUrl = objectUrl;
+      if (bounds && overlayToggle.checked) {
+        renderOverlay(objectUrl, bounds);
+      } else {
+        setDisplayMode(false);
+        radarImage.src = objectUrl;
+        radarImage.alt = `Radar product ${key}`;
+      }
+      showStatus(`Showing ${key}`);
+    } catch (error) {
+      console.error(error);
+      showStatus(`Unable to load image: ${error.message}`, true);
+    }
+  }
+
+  function buildListItem(key) {
+    const li = document.createElement('li');
+    li.textContent = key;
+    li.dataset.key = key;
+    li.addEventListener('click', () => loadImage(key));
+    return li;
+  }
+
+  async function fetchKeys() {
+    const source = sourceSelect.value;
+    const prefix = prefixInput.value.trim();
+    const limit = Number(limitInput.value) || 20;
+
+    state.currentSource = source;
+
+    const params = new URLSearchParams({ source, limit: String(limit) });
+    if (prefix) {
+      params.set('prefix', prefix);
+    }
+
+    showStatus('Loading file list…');
+    fileList.innerHTML = '';
+
+    try {
+      const response = await fetch(`/api/files?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error(`Server responded with ${response.status}`);
+      }
+      const payload = await response.json();
+      const keys = payload.keys || [];
+      if (!keys.length) {
+        showStatus('No files found for the provided filters.');
+        return;
+      }
+      const fragment = document.createDocumentFragment();
+      keys.forEach((key) => fragment.appendChild(buildListItem(key)));
+      fileList.appendChild(fragment);
+      showStatus(`Loaded ${keys.length} file(s). Click a file to render.`);
+    } catch (error) {
+      console.error(error);
+      showStatus(`Unable to load file list: ${error.message}`, true);
+    }
+  }
+
+  function syncThreshold(value) {
+    thresholdSlider.value = value;
+    thresholdInput.value = value;
+  }
+
+  function handleThresholdChange(value) {
+    const numeric = Number(value);
+    if (Number.isNaN(numeric)) {
+      return;
+    }
+    syncThreshold(String(numeric));
+    state.threshold = numeric;
+    if (state.currentKey) {
+      loadImage(state.currentKey, { skipListHighlight: true });
+    }
+  }
+
+  function handleOverlayToggle() {
+    state.overlayEnabled = overlayToggle.checked;
+    if (!state.overlayEnabled) {
+      if (state.overlay) {
+        state.overlay.remove();
+        state.overlay = null;
+      }
+      if (state.lastObjectUrl) {
+        radarImage.src = state.lastObjectUrl;
+        radarImage.classList.remove('hidden');
+        mapContainer.classList.add('hidden');
+      }
+    } else if (state.currentKey) {
+      loadImage(state.currentKey, { skipListHighlight: true });
+    }
+  }
+
+  function runQuickTest() {
+    sourceSelect.value = 's3';
+    state.currentSource = 's3';
+    const quickKey = 'TBW_N0B_2025_06_15_19_01_56';
+    prefixInput.value = quickKey;
+    syncThreshold('23');
+    handleThresholdChange('23');
+    loadImage(quickKey, { skipListHighlight: true });
+    fileList.innerHTML = '';
+    fileList.appendChild(buildListItem(quickKey));
+    setActiveListItem(quickKey);
+  }
+
+  listBtn.addEventListener('click', fetchKeys);
+  thresholdSlider.addEventListener('input', (event) => handleThresholdChange(event.target.value));
+  thresholdInput.addEventListener('change', (event) => handleThresholdChange(event.target.value));
+  sourceSelect.addEventListener('change', () => {
+    state.currentSource = sourceSelect.value;
+    state.currentKey = null;
+    revokeObjectUrl();
+    radarImage.classList.add('hidden');
+    mapContainer.classList.add('hidden');
+    fileList.innerHTML = '';
+    showStatus('Select "Fetch files" to load products for the new source.');
+  });
+  overlayToggle.addEventListener('change', handleOverlayToggle);
+  quickTestBtn.addEventListener('click', runQuickTest);
+
+  // Initialize defaults
+  syncThreshold(String(state.threshold));
+  showStatus('Set filters then click "Fetch files" to begin.');
+})();

--- a/static/radar.html
+++ b/static/radar.html
@@ -4,33 +4,82 @@
 <meta charset="utf-8"/>
 <title>Radar Viewer</title>
 <style>
-body{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;margin:16px}
-#panel{display:flex;gap:16px;align-items:flex-start}
-#list{width:460px;height:70vh;overflow:auto;border:1px solid #ccc;padding:8px}
-#viewer{flex:1}
-#viewer img{max-width:100%;height:auto;border:1px solid #ccc;display:block}
-label{display:block;margin-top:8px}
-#msg{margin-top:8px;color:#b00;white-space:pre-wrap}
-.small{font-size:12px;color:#555}
+*{box-sizing:border-box}
+body{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;margin:0;background:#f5f6fa;color:#1f2933}
+header{background:#0f4c81;color:#fff;padding:20px 24px}
+h1{margin:0;font-size:28px}
+header p{margin:4px 0 0;font-size:14px;opacity:0.85}
+#controls{background:#fff;padding:16px 24px;display:flex;flex-wrap:wrap;gap:16px;border-bottom:1px solid #d8e2f0}
+#controls label{display:flex;flex-direction:column;font-size:13px;color:#334155;min-width:160px}
+#controls select,#controls input{margin-top:4px;padding:6px 8px;border:1px solid #cbd5e1;border-radius:6px;font-size:14px}
+#refreshBtn{align-self:flex-end;padding:8px 16px;background:#0f4c81;color:#fff;border:none;border-radius:6px;font-size:14px;cursor:pointer;transition:background .2s}
+#refreshBtn:hover{background:#0c3a63}
+#layout{display:grid;grid-template-columns:320px 1fr;gap:0;min-height:calc(100vh - 168px)}
+#radarListContainer{background:#fff;border-right:1px solid #d8e2f0;overflow:auto;padding:16px}
+#radarList{list-style:none;margin:0;padding:0}
+#radarList li{padding:10px 12px;border-radius:8px;cursor:pointer;border:1px solid transparent;display:flex;flex-direction:column;gap:2px;margin-bottom:8px;transition:background .2s,border-color .2s}
+#radarList li:hover{background:#f1f5f9;border-color:#cbd5e1}
+#radarList li.active{background:#0f4c8114;border-color:#0f4c8140}
+#radarList .radar-code{font-weight:600;font-size:15px;color:#0f4c81}
+#radarList .radar-location{font-size:13px;color:#475569}
+#details{padding:24px;overflow:auto}
+#selectedInfo{margin-bottom:24px;display:flex;flex-wrap:wrap;gap:16px;align-items:center}
+#selectedInfo h2{margin:0;font-size:24px;color:#0f4c81}
+#selectedInfo .meta{font-size:14px;color:#475569}
+#images{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:24px}
+.tilt-card{background:#fff;border-radius:12px;box-shadow:0 6px 18px -10px rgba(15,76,129,.6);padding:16px;display:flex;flex-direction:column;gap:12px}
+.tilt-card h3{margin:0;font-size:18px;color:#0f4c81}
+.view-pair{display:flex;gap:12px;flex-wrap:wrap}
+.view{flex:1;min-width:220px}
+.view-title{font-size:13px;color:#64748b;margin-bottom:6px;text-transform:uppercase;letter-spacing:.05em}
+.view img{width:100%;border-radius:8px;border:1px solid #cbd5e1;background:#0f172a}
+#status{padding:12px 24px;font-size:14px;color:#0f4c81;background:#e0f2fe;border-top:1px solid #bae6fd}
+#status.error{background:#fee2e2;color:#991b1b;border-top-color:#fecaca}
+#status.hidden{display:none}
+.chip{display:inline-flex;align-items:center;padding:4px 8px;border-radius:999px;background:#e2e8f0;font-size:12px;color:#475569}
+@media (max-width:960px){#layout{grid-template-columns:1fr}#radarListContainer{border-right:none;border-bottom:1px solid #d8e2f0}}
 </style>
 </head>
 <body>
-<h1>Radar Viewer</h1>
-<div id="panel">
-  <div>
-    <button id="refresh">List files</button>
-    <label>Prefix <input id="prefix" value="KMLB_SDUS52"/></label>
-    <label>DBZ Threshold <input type="number" id="dbz" value="23" min="0" max="80"/></label>
-    <div id="list"></div>
-    <div class="small">Items without an extension are fine - the viewer will try .nc and .mdv.nc automatically.</div>
-    <button id="quick">Quick test</button>
-    <div id="msg"></div>
-  </div>
-  <div id="viewer">
-    <a id="openLink" href="#" target="_blank" style="display:none;margin-bottom:8px">Open image in new tab</a>
-    <img id="radar" alt="radar image"/>
-  </div>
+<header>
+  <h1>Radar Viewer</h1>
+  <p>Latest NEXRAD Level III base reflectivity — four tilts, overview + local zoom</p>
+</header>
+<section id="controls">
+  <label>Data source
+    <select id="sourceSelect">
+      <option value="s3">Amazon S3</option>
+      <option value="thread">NCEI Thread Server</option>
+    </select>
+  </label>
+  <label>Prefix filter
+    <input id="prefixInput" placeholder="Optional prefix"/>
+  </label>
+  <label>Search radar
+    <input id="searchInput" placeholder="City, state or call sign"/>
+  </label>
+  <label>Sort by
+    <select id="sortSelect">
+      <option value="location">Location</option>
+      <option value="radar">Call sign</option>
+    </select>
+  </label>
+  <button id="refreshBtn">Refresh scans</button>
+</section>
+<div id="layout">
+  <aside id="radarListContainer">
+    <ul id="radarList"></ul>
+  </aside>
+  <section id="details">
+    <div id="selectedInfo">
+      <h2 id="selectedTitle">Select a radar</h2>
+      <span class="meta" id="selectedMeta"></span>
+      <span class="chip" id="selectedUpdated" style="display:none"></span>
+    </div>
+    <div id="images"></div>
+  </section>
 </div>
-<script src="/static/radar.js?v=2" defer></script>
+<div id="status" class="hidden"></div>
+<script src="/static/radar.js?v=3" defer></script>
 </body>
 </html>

--- a/static/radar.html
+++ b/static/radar.html
@@ -4,33 +4,86 @@
 <meta charset="utf-8"/>
 <title>Radar Viewer</title>
 <style>
-body{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;margin:16px}
-#panel{display:flex;gap:16px;align-items:flex-start}
-#list{width:460px;height:70vh;overflow:auto;border:1px solid #ccc;padding:8px}
-#viewer{flex:1}
-#viewer img{max-width:100%;height:auto;border:1px solid #ccc;display:block}
-label{display:block;margin-top:8px}
-#msg{margin-top:8px;color:#b00;white-space:pre-wrap}
-.small{font-size:12px;color:#555}
+*{box-sizing:border-box}
+body{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;margin:0;background:#f5f6fa;color:#1f2933}
+header{background:#0f4c81;color:#fff;padding:20px 24px}
+h1{margin:0;font-size:28px}
+header p{margin:4px 0 0;font-size:14px;opacity:0.85}
+#controls{background:#fff;padding:16px 24px;display:flex;flex-wrap:wrap;gap:16px;border-bottom:1px solid #d8e2f0}
+#controls label{display:flex;flex-direction:column;font-size:13px;color:#334155;min-width:160px}
+#controls select,#controls input{margin-top:4px;padding:6px 8px;border:1px solid #cbd5e1;border-radius:6px;font-size:14px}
+#refreshBtn{align-self:flex-end;padding:8px 16px;background:#0f4c81;color:#fff;border:none;border-radius:6px;font-size:14px;cursor:pointer;transition:background .2s}
+#refreshBtn:hover{background:#0c3a63}
+#layout{display:grid;grid-template-columns:320px 1fr;gap:0;min-height:calc(100vh - 168px)}
+#radarListContainer{background:#fff;border-right:1px solid #d8e2f0;overflow:auto;padding:16px}
+#radarList{list-style:none;margin:0;padding:0}
+#radarList li{padding:10px 12px;border-radius:8px;cursor:pointer;border:1px solid transparent;display:flex;flex-direction:column;gap:2px;margin-bottom:8px;transition:background .2s,border-color .2s}
+#radarList li:hover{background:#f1f5f9;border-color:#cbd5e1}
+#radarList li.active{background:#0f4c8114;border-color:#0f4c8140}
+#radarList .radar-code{font-weight:600;font-size:15px;color:#0f4c81}
+#radarList .radar-location{font-size:13px;color:#475569}
+#details{padding:24px;overflow:auto}
+#selectedInfo{margin-bottom:24px;display:flex;flex-wrap:wrap;gap:16px;align-items:center}
+#selectedInfo h2{margin:0;font-size:24px;color:#0f4c81}
+#selectedInfo .meta{font-size:14px;color:#475569}
+#images{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:24px}
+.tilt-card{background:#fff;border-radius:12px;box-shadow:0 6px 18px -10px rgba(15,76,129,.6);padding:16px;display:flex;flex-direction:column;gap:12px}
+.tilt-card h3{margin:0;font-size:18px;color:#0f4c81}
+.view-pair{display:flex;gap:12px;flex-wrap:wrap}
+.view{flex:1;min-width:220px}
+.view-title{font-size:13px;color:#64748b;margin-bottom:6px;text-transform:uppercase;letter-spacing:.05em}
+.view img{width:100%;border-radius:8px;border:1px solid #cbd5e1;background:#0f172a}
+#status{padding:12px 24px;font-size:14px;color:#0f4c81;background:#e0f2fe;border-top:1px solid #bae6fd}
+#status.error{background:#fee2e2;color:#991b1b;border-top-color:#fecaca}
+#status.hidden{display:none}
+.chip{display:inline-flex;align-items:center;padding:4px 8px;border-radius:999px;background:#e2e8f0;font-size:12px;color:#475569}
+@media (max-width:960px){#layout{grid-template-columns:1fr}#radarListContainer{border-right:none;border-bottom:1px solid #d8e2f0}}
 </style>
 </head>
 <body>
-<h1>Radar Viewer</h1>
-<div id="panel">
-  <div>
-    <button id="refresh">List files</button>
-    <label>Prefix <input id="prefix" value="KMLB_SDUS52"/></label>
-    <label>DBZ Threshold <input type="number" id="dbz" value="23" min="0" max="80"/></label>
-    <div id="list"></div>
-    <div class="small">Items without an extension are fine - the viewer will try .nc and .mdv.nc automatically.</div>
-    <button id="quick">Quick test</button>
-    <div id="msg"></div>
-  </div>
-  <div id="viewer">
-    <a id="openLink" href="#" target="_blank" style="display:none;margin-bottom:8px">Open image in new tab</a>
-    <img id="radar" alt="radar image"/>
-  </div>
+<header>
+  <h1>Radar Viewer</h1>
+  <p>Latest NEXRAD Level III base reflectivity — four tilts, overview + local zoom</p>
+</header>
+<section id="controls">
+  <label>Data source
+    <select id="sourceSelect">
+      <option value="s3">Amazon S3</option>
+      <option value="thread">NCEI Thread Server</option>
+    </select>
+  </label>
+  <label>Prefix filter
+    <select id="prefixSelect">
+      <option value="">All locations</option>
+    </select>
+  </label>
+  <label>Search radar
+    <select id="searchSelect">
+      <option value="">Select a radar…</option>
+    </select>
+  </label>
+  <label>Sort by
+    <select id="sortSelect">
+      <option value="location">Location</option>
+      <option value="radar">Call sign</option>
+    </select>
+  </label>
+  <button id="refreshBtn">Refresh scans</button>
+</section>
+<div id="layout">
+  <aside id="radarListContainer">
+    <ul id="radarList"></ul>
+  </aside>
+  <section id="details">
+    <div id="selectedInfo">
+      <h2 id="selectedTitle">Select a radar</h2>
+      <span class="meta" id="selectedMeta"></span>
+      <span class="chip" id="selectedUpdated" style="display:none"></span>
+    </div>
+    <div id="images"></div>
+  </section>
 </div>
-<script src="/static/radar.js?v=2" defer></script>
+<div id="status" class="hidden"></div>
+<script src="/static/radar.js?v=3" defer></script>
 </body>
 </html>

--- a/static/radar.html
+++ b/static/radar.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Radar Data Viewer</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-o9N1j7kP6+1jKqNvZFV7h6jhA3H0CwZ4ZjL2roV4bBU=" crossorigin="" />
+    <style>
+        body {
+            font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+            margin: 0;
+            background: #f5f7fb;
+            color: #1a1a1a;
+        }
+
+        header {
+            background: #1d3557;
+            color: #fff;
+            padding: 1rem 2rem;
+            font-size: 1.5rem;
+            font-weight: 600;
+        }
+
+        .app-container {
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+        }
+
+        .content {
+            display: flex;
+            flex: 1;
+            overflow: hidden;
+        }
+
+        .sidebar {
+            width: 340px;
+            background: #ffffff;
+            box-shadow: 2px 0 8px rgba(0, 0, 0, 0.05);
+            display: flex;
+            flex-direction: column;
+        }
+
+        .controls {
+            padding: 1rem 1.5rem;
+            border-bottom: 1px solid #e6ecf5;
+        }
+
+        .controls label {
+            display: block;
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin-bottom: 0.35rem;
+            color: #4a5568;
+        }
+
+        .controls select,
+        .controls input,
+        .controls button {
+            width: 100%;
+            padding: 0.5rem 0.75rem;
+            margin-bottom: 0.75rem;
+            border: 1px solid #cbd5e0;
+            border-radius: 6px;
+            font-size: 0.95rem;
+        }
+
+        .controls button {
+            background: #457b9d;
+            color: #fff;
+            cursor: pointer;
+            border: none;
+        }
+
+        .controls button:hover {
+            background: #2a5880;
+        }
+
+        .threshold-group {
+            display: grid;
+            grid-template-columns: 1fr 70px;
+            gap: 0.5rem;
+            align-items: center;
+        }
+
+        .list-header {
+            padding: 0.75rem 1.5rem;
+            font-weight: 600;
+            color: #1d3557;
+        }
+
+        .file-list {
+            flex: 1;
+            overflow-y: auto;
+            margin: 0;
+            padding: 0 1.5rem 1.5rem 1.5rem;
+            list-style: none;
+        }
+
+        .file-list li {
+            padding: 0.55rem 0.75rem;
+            border: 1px solid transparent;
+            border-radius: 6px;
+            cursor: pointer;
+            margin-bottom: 0.5rem;
+            transition: background 0.2s, border-color 0.2s;
+            word-break: break-word;
+        }
+
+        .file-list li:hover {
+            background: #f1f5f9;
+            border-color: #cbd5e0;
+        }
+
+        .file-list li.active {
+            background: #e0f2fe;
+            border-color: #1d4ed8;
+            color: #1d4ed8;
+        }
+
+        .viewer {
+            flex: 1;
+            position: relative;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .viewer-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 1rem 1.5rem;
+            background: #ffffff;
+            border-bottom: 1px solid #e6ecf5;
+        }
+
+        .viewer-toolbar label {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.95rem;
+            color: #2d3748;
+        }
+
+        .viewer-toolbar button {
+            padding: 0.45rem 0.9rem;
+            border-radius: 6px;
+            border: none;
+            background: #1d3557;
+            color: #fff;
+            cursor: pointer;
+        }
+
+        .viewer-toolbar button:hover {
+            background: #14233b;
+        }
+
+        #map {
+            flex: 1;
+        }
+
+        #radarImage {
+            max-width: 100%;
+            max-height: calc(100vh - 150px);
+            margin: 1.5rem auto;
+            display: block;
+            border-radius: 10px;
+            box-shadow: 0 12px 25px rgba(15, 23, 42, 0.15);
+        }
+
+        .hidden {
+            display: none !important;
+        }
+
+        .status {
+            padding: 0.5rem 1.5rem;
+            background: #fff7ed;
+            border-top: 1px solid #fcd9bd;
+            color: #9a3412;
+            font-size: 0.9rem;
+        }
+
+        @media (max-width: 960px) {
+            .content {
+                flex-direction: column;
+            }
+
+            .sidebar {
+                width: 100%;
+                max-height: 45vh;
+            }
+
+            #radarImage {
+                max-height: 50vh;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="app-container">
+        <header>Radar Data Viewer</header>
+        <div class="content">
+            <aside class="sidebar">
+                <div class="controls">
+                    <label for="sourceSelect">Data source</label>
+                    <select id="sourceSelect">
+                        <option value="s3">AWS S3</option>
+                        <option value="thread">NOAA/NCEI Thread</option>
+                    </select>
+
+                    <label for="prefixInput">Prefix filter</label>
+                    <input id="prefixInput" type="text" placeholder="e.g. TBW_N0B_2025" />
+
+                    <label for="limitInput">Result limit</label>
+                    <input id="limitInput" type="number" value="20" min="1" max="500" />
+
+                    <label>DBZ Threshold</label>
+                    <div class="threshold-group">
+                        <input id="thresholdSlider" type="range" min="-20" max="80" value="23" />
+                        <input id="thresholdInput" type="number" min="-20" max="80" value="23" />
+                    </div>
+
+                    <button id="listBtn" type="button">Fetch files</button>
+                </div>
+
+                <div class="list-header">Available files</div>
+                <ul id="fileList" class="file-list"></ul>
+            </aside>
+
+            <section class="viewer">
+                <div class="viewer-toolbar">
+                    <label><input type="checkbox" id="overlayToggle" checked /> Map overlay</label>
+                    <button id="quickTest" type="button">Quick test</button>
+                </div>
+                <div id="map" class="hidden"></div>
+                <img id="radarImage" class="hidden" alt="Radar product" />
+                <div id="status" class="status hidden"></div>
+            </section>
+        </div>
+    </div>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o2Qo+Cn8xqGa9hb9TIMfNWO56VsoEq+ySt5mTRHw3tw=" crossorigin=""></script>
+    <script src="js/radar.js"></script>
+</body>
+</html>

--- a/static/radar.html
+++ b/static/radar.html
@@ -48,6 +48,7 @@ header p{margin:4px 0 0;font-size:14px;opacity:0.85}
 <section id="controls">
   <label>Data source
     <select id="sourceSelect">
+      <option value="local" selected>Local cache</option>
       <option value="s3">Amazon S3</option>
       <option value="thread">NCEI Thread Server</option>
     </select>
@@ -84,6 +85,6 @@ header p{margin:4px 0 0;font-size:14px;opacity:0.85}
   </section>
 </div>
 <div id="status" class="hidden"></div>
-<script src="/static/radar.js?v=3" defer></script>
+<script src="/static/radar.js?v=4" defer></script>
 </body>
 </html>

--- a/static/radar.html
+++ b/static/radar.html
@@ -1,245 +1,36 @@
-<!DOCTYPE html>
-<html lang="en">
+<!doctype html>
+<html>
 <head>
-    <meta charset="utf-8" />
-    <title>Radar Data Viewer</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-o9N1j7kP6+1jKqNvZFV7h6jhA3H0CwZ4ZjL2roV4bBU=" crossorigin="" />
-    <style>
-        body {
-            font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-            margin: 0;
-            background: #f5f7fb;
-            color: #1a1a1a;
-        }
-
-        header {
-            background: #1d3557;
-            color: #fff;
-            padding: 1rem 2rem;
-            font-size: 1.5rem;
-            font-weight: 600;
-        }
-
-        .app-container {
-            display: flex;
-            flex-direction: column;
-            height: 100vh;
-        }
-
-        .content {
-            display: flex;
-            flex: 1;
-            overflow: hidden;
-        }
-
-        .sidebar {
-            width: 340px;
-            background: #ffffff;
-            box-shadow: 2px 0 8px rgba(0, 0, 0, 0.05);
-            display: flex;
-            flex-direction: column;
-        }
-
-        .controls {
-            padding: 1rem 1.5rem;
-            border-bottom: 1px solid #e6ecf5;
-        }
-
-        .controls label {
-            display: block;
-            font-size: 0.85rem;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            margin-bottom: 0.35rem;
-            color: #4a5568;
-        }
-
-        .controls select,
-        .controls input,
-        .controls button {
-            width: 100%;
-            padding: 0.5rem 0.75rem;
-            margin-bottom: 0.75rem;
-            border: 1px solid #cbd5e0;
-            border-radius: 6px;
-            font-size: 0.95rem;
-        }
-
-        .controls button {
-            background: #457b9d;
-            color: #fff;
-            cursor: pointer;
-            border: none;
-        }
-
-        .controls button:hover {
-            background: #2a5880;
-        }
-
-        .threshold-group {
-            display: grid;
-            grid-template-columns: 1fr 70px;
-            gap: 0.5rem;
-            align-items: center;
-        }
-
-        .list-header {
-            padding: 0.75rem 1.5rem;
-            font-weight: 600;
-            color: #1d3557;
-        }
-
-        .file-list {
-            flex: 1;
-            overflow-y: auto;
-            margin: 0;
-            padding: 0 1.5rem 1.5rem 1.5rem;
-            list-style: none;
-        }
-
-        .file-list li {
-            padding: 0.55rem 0.75rem;
-            border: 1px solid transparent;
-            border-radius: 6px;
-            cursor: pointer;
-            margin-bottom: 0.5rem;
-            transition: background 0.2s, border-color 0.2s;
-            word-break: break-word;
-        }
-
-        .file-list li:hover {
-            background: #f1f5f9;
-            border-color: #cbd5e0;
-        }
-
-        .file-list li.active {
-            background: #e0f2fe;
-            border-color: #1d4ed8;
-            color: #1d4ed8;
-        }
-
-        .viewer {
-            flex: 1;
-            position: relative;
-            display: flex;
-            flex-direction: column;
-        }
-
-        .viewer-toolbar {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            padding: 1rem 1.5rem;
-            background: #ffffff;
-            border-bottom: 1px solid #e6ecf5;
-        }
-
-        .viewer-toolbar label {
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-            font-size: 0.95rem;
-            color: #2d3748;
-        }
-
-        .viewer-toolbar button {
-            padding: 0.45rem 0.9rem;
-            border-radius: 6px;
-            border: none;
-            background: #1d3557;
-            color: #fff;
-            cursor: pointer;
-        }
-
-        .viewer-toolbar button:hover {
-            background: #14233b;
-        }
-
-        #map {
-            flex: 1;
-        }
-
-        #radarImage {
-            max-width: 100%;
-            max-height: calc(100vh - 150px);
-            margin: 1.5rem auto;
-            display: block;
-            border-radius: 10px;
-            box-shadow: 0 12px 25px rgba(15, 23, 42, 0.15);
-        }
-
-        .hidden {
-            display: none !important;
-        }
-
-        .status {
-            padding: 0.5rem 1.5rem;
-            background: #fff7ed;
-            border-top: 1px solid #fcd9bd;
-            color: #9a3412;
-            font-size: 0.9rem;
-        }
-
-        @media (max-width: 960px) {
-            .content {
-                flex-direction: column;
-            }
-
-            .sidebar {
-                width: 100%;
-                max-height: 45vh;
-            }
-
-            #radarImage {
-                max-height: 50vh;
-            }
-        }
-    </style>
+<meta charset="utf-8"/>
+<title>Radar Viewer</title>
+<style>
+body{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;margin:16px}
+#panel{display:flex;gap:16px;align-items:flex-start}
+#list{width:460px;height:70vh;overflow:auto;border:1px solid #ccc;padding:8px}
+#viewer{flex:1}
+#viewer img{max-width:100%;height:auto;border:1px solid #ccc;display:block}
+label{display:block;margin-top:8px}
+#msg{margin-top:8px;color:#b00;white-space:pre-wrap}
+.small{font-size:12px;color:#555}
+</style>
 </head>
 <body>
-    <div class="app-container">
-        <header>Radar Data Viewer</header>
-        <div class="content">
-            <aside class="sidebar">
-                <div class="controls">
-                    <label for="sourceSelect">Data source</label>
-                    <select id="sourceSelect">
-                        <option value="s3">AWS S3</option>
-                        <option value="thread">NOAA/NCEI Thread</option>
-                    </select>
-
-                    <label for="prefixInput">Prefix filter</label>
-                    <input id="prefixInput" type="text" placeholder="e.g. TBW_N0B_2025" />
-
-                    <label for="limitInput">Result limit</label>
-                    <input id="limitInput" type="number" value="20" min="1" max="500" />
-
-                    <label>DBZ Threshold</label>
-                    <div class="threshold-group">
-                        <input id="thresholdSlider" type="range" min="-20" max="80" value="23" />
-                        <input id="thresholdInput" type="number" min="-20" max="80" value="23" />
-                    </div>
-
-                    <button id="listBtn" type="button">Fetch files</button>
-                </div>
-
-                <div class="list-header">Available files</div>
-                <ul id="fileList" class="file-list"></ul>
-            </aside>
-
-            <section class="viewer">
-                <div class="viewer-toolbar">
-                    <label><input type="checkbox" id="overlayToggle" checked /> Map overlay</label>
-                    <button id="quickTest" type="button">Quick test</button>
-                </div>
-                <div id="map" class="hidden"></div>
-                <img id="radarImage" class="hidden" alt="Radar product" />
-                <div id="status" class="status hidden"></div>
-            </section>
-        </div>
-    </div>
-
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o2Qo+Cn8xqGa9hb9TIMfNWO56VsoEq+ySt5mTRHw3tw=" crossorigin=""></script>
-    <script src="js/radar.js"></script>
+<h1>Radar Viewer</h1>
+<div id="panel">
+  <div>
+    <button id="refresh">List files</button>
+    <label>Prefix <input id="prefix" value="KMLB_SDUS52"/></label>
+    <label>DBZ Threshold <input type="number" id="dbz" value="23" min="0" max="80"/></label>
+    <div id="list"></div>
+    <div class="small">Items without an extension are fine - the viewer will try .nc and .mdv.nc automatically.</div>
+    <button id="quick">Quick test</button>
+    <div id="msg"></div>
+  </div>
+  <div id="viewer">
+    <a id="openLink" href="#" target="_blank" style="display:none;margin-bottom:8px">Open image in new tab</a>
+    <img id="radar" alt="radar image"/>
+  </div>
+</div>
+<script src="/static/radar.js?v=2" defer></script>
 </body>
 </html>

--- a/static/radar.js
+++ b/static/radar.js
@@ -1,0 +1,104 @@
+(function(){
+  const qs = (id) => document.getElementById(id);
+  const listEl   = qs('list');
+  const imgEl    = qs('radar');
+  const dbzEl    = qs('dbz');
+  const prefixEl = qs('prefix');
+  const linkEl   = qs('openLink');
+  const msgEl    = qs('msg');
+
+  function msg(s){ msgEl.textContent = s || ""; }
+
+  async function listFiles() {
+    try {
+      msg("");
+      listEl.innerHTML = "Loading...";
+      const r = await fetch('/radar_files', {cache:'no-store'});
+      if (!r.ok) throw new Error(`HTTP ${r.status} ${r.statusText}`);
+      const data = await r.json();
+      const pref = (prefixEl.value || '').trim().toUpperCase();
+      const all = Array.isArray(data.files) ? data.files : [];
+      const filtered = all.filter(f => pref ? f.toUpperCase().includes(pref) : true);
+      const header = document.createElement('div');
+      header.className = 'small';
+      header.textContent = `Total: ${all.length} | Showing: ${filtered.length}`;
+      listEl.innerHTML = '';
+      listEl.appendChild(header);
+      filtered.forEach(k => {
+        const a = document.createElement('a');
+        a.href = '#';
+        a.textContent = k;
+        a.style.display = 'block';
+        a.onclick = (e) => { e.preventDefault(); showAuto(k); };
+        listEl.appendChild(a);
+      });
+      if (filtered.length === 0) {
+        const d = document.createElement('div');
+        d.textContent = 'No matching items.';
+        listEl.appendChild(d);
+      }
+    } catch (e) {
+      listEl.textContent = 'Failed to list files: ' + e;
+    }
+  }
+
+  function currentPathFromImg() {
+    try {
+      const u = new URL(imgEl.dataset.src || '', window.location.origin);
+      const p = u.searchParams.get('path');
+      return p ? decodeURIComponent(p) : null;
+    } catch { return null; }
+  }
+
+  async function fetchAsImage(url) {
+    const r = await fetch(url, {cache:'no-store'});
+    if (!r.ok) {
+      const txt = await r.text();
+      throw new Error(`HTTP ${r.status} ${r.statusText}\n` + txt.slice(0,400));
+    }
+    const blob = await r.blob();                 // works even if server says application/json
+    const objUrl = URL.createObjectURL(blob);
+    imgEl.src = objUrl;
+    imgEl.dataset.src = url;                     // remember source URL for re-render on DBZ change
+    linkEl.href = url;
+    linkEl.style.display = 'inline-block';
+  }
+
+  async function showResolved(path, dbz) {
+    const url = '/radar_filter_q?path=' + encodeURIComponent(path) + '&threshold=' + dbz;
+    await fetchAsImage(url);
+    msg("");
+  }
+
+  async function showAuto(basePath) {
+    msg("");
+    imgEl.removeAttribute('src');
+    linkEl.style.display = 'none';
+    const dbz = parseInt(dbzEl.value || '23', 10);
+    const candidates = [basePath];
+    if (!/\.nc$/i.test(basePath)) {
+      candidates.push(basePath + '.nc');
+      if (!/\.mdv\.nc$/i.test(basePath)) candidates.push(basePath + '.mdv.nc');
+    }
+    let lastErr = null;
+    for (const c of candidates) {
+      try { await showResolved(c, dbz); return; } catch(e){ lastErr = e; }
+    }
+    msg('Could not render any candidate:\n' + candidates.join('\n') + '\n\nLast error: ' + lastErr);
+  }
+
+  function wire() {
+    qs('refresh').onclick = listFiles;
+    qs('quick').onclick   = () => showAuto('radar_3_data/KMLB_SDUS52_TZ0MCO_202405151906.nc');
+    dbzEl.onchange        = () => { const cur = currentPathFromImg(); if (cur) showAuto(cur); };
+    listFiles();
+  }
+
+  window.addEventListener('error', (e) => { msg('JS error: ' + e.message); });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', wire);
+  } else {
+    wire();
+  }
+})();

--- a/static/radar.js
+++ b/static/radar.js
@@ -1,104 +1,324 @@
-(function(){
-  const qs = (id) => document.getElementById(id);
-  const listEl   = qs('list');
-  const imgEl    = qs('radar');
-  const dbzEl    = qs('dbz');
-  const prefixEl = qs('prefix');
-  const linkEl   = qs('openLink');
-  const msgEl    = qs('msg');
+(function () {
+  const dom = {
+    source: document.getElementById('sourceSelect'),
+    prefix: document.getElementById('prefixInput'),
+    search: document.getElementById('searchInput'),
+    sort: document.getElementById('sortSelect'),
+    refresh: document.getElementById('refreshBtn'),
+    list: document.getElementById('radarList'),
+    title: document.getElementById('selectedTitle'),
+    meta: document.getElementById('selectedMeta'),
+    updated: document.getElementById('selectedUpdated'),
+    images: document.getElementById('images'),
+    status: document.getElementById('status'),
+  };
 
-  function msg(s){ msgEl.textContent = s || ""; }
+  const state = {
+    source: dom.source.value,
+    radars: [],
+    filtered: [],
+    selectedId: null,
+    sortBy: dom.sort.value,
+  };
 
-  async function listFiles() {
+  function setStatus(message, isError = false) {
+    if (!message) {
+      dom.status.classList.add('hidden');
+      dom.status.textContent = '';
+      dom.status.classList.remove('error');
+      return;
+    }
+    dom.status.textContent = message;
+    dom.status.classList.remove('hidden');
+    dom.status.classList.toggle('error', isError);
+  }
+
+  function normaliseText(value) {
+    return (value || '').toString().toLowerCase();
+  }
+
+  function formatTilt(tilt) {
+    if (typeof tilt === 'number' && !Number.isNaN(tilt)) {
+      return `${tilt.toFixed(1)}° tilt`;
+    }
+    return 'Tilt';
+  }
+
+  function toUtcText(timestamp) {
+    if (!timestamp) {
+      return null;
+    }
+    const ts = timestamp.endsWith('Z') ? timestamp : `${timestamp}Z`;
+    const date = new Date(ts);
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+    return `${date.toUTCString()}`;
+  }
+
+  function clearImages() {
+    dom.images.innerHTML = '';
+  }
+
+  async function loadImage(img, key, view) {
+    if (!key) {
+      return;
+    }
+    const params = new URLSearchParams({
+      source: state.source,
+      key,
+      view,
+    });
     try {
-      msg("");
-      listEl.innerHTML = "Loading...";
-      const r = await fetch('/radar_files', {cache:'no-store'});
-      if (!r.ok) throw new Error(`HTTP ${r.status} ${r.statusText}`);
-      const data = await r.json();
-      const pref = (prefixEl.value || '').trim().toUpperCase();
-      const all = Array.isArray(data.files) ? data.files : [];
-      const filtered = all.filter(f => pref ? f.toUpperCase().includes(pref) : true);
-      const header = document.createElement('div');
-      header.className = 'small';
-      header.textContent = `Total: ${all.length} | Showing: ${filtered.length}`;
-      listEl.innerHTML = '';
-      listEl.appendChild(header);
-      filtered.forEach(k => {
-        const a = document.createElement('a');
-        a.href = '#';
-        a.textContent = k;
-        a.style.display = 'block';
-        a.onclick = (e) => { e.preventDefault(); showAuto(k); };
-        listEl.appendChild(a);
-      });
-      if (filtered.length === 0) {
-        const d = document.createElement('div');
-        d.textContent = 'No matching items.';
-        listEl.appendChild(d);
+      const response = await fetch(`/api/file?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error(`Server responded with ${response.status}`);
       }
-    } catch (e) {
-      listEl.textContent = 'Failed to list files: ' + e;
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      img.src = url;
+      img.dataset.url = url;
+      const metadataHeader = response.headers.get('X-Radar-Metadata');
+      if (metadataHeader && view === 'zoom') {
+        try {
+          const metadata = JSON.parse(metadataHeader);
+          if (metadata.title) {
+            img.setAttribute('alt', metadata.title);
+          }
+        } catch (error) {
+          console.debug('Unable to parse radar metadata header', error);
+        }
+      }
+    } catch (error) {
+      console.error(error);
+      setStatus(`Failed to load radar image: ${error.message}`, true);
     }
   }
 
-  function currentPathFromImg() {
+  function renderImages(radar) {
+    clearImages();
+    if (!radar || !Array.isArray(radar.products)) {
+      return;
+    }
+    radar.products.forEach((product) => {
+      const card = document.createElement('div');
+      card.className = 'tilt-card';
+
+      const heading = document.createElement('h3');
+      const tiltLabel = formatTilt(product.tilt_degrees);
+      heading.textContent = `${product.code} — ${tiltLabel}`;
+      card.appendChild(heading);
+
+      const stamp = toUtcText(product.timestamp);
+      if (stamp) {
+        const stampEl = document.createElement('div');
+        stampEl.className = 'meta';
+        stampEl.textContent = `Scan time: ${stamp}`;
+        card.appendChild(stampEl);
+      }
+
+      const pair = document.createElement('div');
+      pair.className = 'view-pair';
+
+      ['overview', 'zoom'].forEach((view) => {
+        const container = document.createElement('div');
+        container.className = 'view';
+        const title = document.createElement('div');
+        title.className = 'view-title';
+        title.textContent = view === 'overview' ? 'State overview' : 'Local zoom';
+        const img = document.createElement('img');
+        img.alt = `${product.code} ${view}`;
+        img.loading = 'lazy';
+        container.appendChild(title);
+        container.appendChild(img);
+        pair.appendChild(container);
+        loadImage(img, product.key, view);
+      });
+
+      card.appendChild(pair);
+      dom.images.appendChild(card);
+    });
+  }
+
+  function updateSelection(radar) {
+    if (!radar) {
+      dom.title.textContent = 'Select a radar';
+      dom.meta.textContent = '';
+      dom.updated.style.display = 'none';
+      clearImages();
+      return;
+    }
+
+    const location = radar.location || 'Unknown location';
+    dom.title.textContent = `${radar.radar_id}${location ? ' — ' + location : ''}`;
+
+    const pieces = [];
+    if (radar.product_name) {
+      pieces.push(radar.product_name);
+    }
+    if (radar.elevation_degrees != null) {
+      pieces.push(`${radar.elevation_degrees.toFixed(1)}° tilt`);
+    }
+    dom.meta.textContent = pieces.join(' • ');
+
+    const updatedText = toUtcText(radar.product_time || radar.volume_time);
+    if (updatedText) {
+      dom.updated.textContent = `Updated ${updatedText}`;
+      dom.updated.style.display = 'inline-flex';
+    } else {
+      dom.updated.style.display = 'none';
+    }
+
+    renderImages(radar);
+  }
+
+  function setActiveListItem() {
+    const items = dom.list.querySelectorAll('li');
+    items.forEach((li) => {
+      li.classList.toggle('active', li.dataset.radarId === state.selectedId);
+    });
+  }
+
+  function handleSelect(radarId) {
+    state.selectedId = radarId;
+    const radar = state.radars.find((item) => item.radar_id === radarId);
+    setActiveListItem();
+    updateSelection(radar);
+  }
+
+  function renderList() {
+    const query = normaliseText(dom.search.value);
+    const items = state.radars.filter((radar) => {
+      if (!query) {
+        return true;
+      }
+      const haystack = [radar.radar_id, radar.raw_radar, radar.location, radar.city, radar.state]
+        .map(normaliseText)
+        .join(' ');
+      return haystack.includes(query);
+    });
+
+    dom.list.innerHTML = '';
+
+    if (!items.length) {
+      const placeholder = document.createElement('li');
+      placeholder.textContent = 'No radar sites match the current filters.';
+      placeholder.style.cursor = 'default';
+      placeholder.style.color = '#64748b';
+      dom.list.appendChild(placeholder);
+      return;
+    }
+
+    items.forEach((radar) => {
+      const li = document.createElement('li');
+      li.dataset.radarId = radar.radar_id;
+
+      const code = document.createElement('span');
+      code.className = 'radar-code';
+      code.textContent = radar.radar_id;
+      li.appendChild(code);
+
+      const location = document.createElement('span');
+      location.className = 'radar-location';
+      location.textContent = radar.location || 'Unknown location';
+      li.appendChild(location);
+
+      li.addEventListener('click', () => handleSelect(radar.radar_id));
+      dom.list.appendChild(li);
+    });
+
+    setActiveListItem();
+  }
+
+  function sortRadars() {
+    const sortBy = state.sortBy;
+    state.radars.sort((a, b) => {
+      if (sortBy === 'radar') {
+        return a.radar_id.localeCompare(b.radar_id);
+      }
+      const nameA = (a.location || '').toUpperCase();
+      const nameB = (b.location || '').toUpperCase();
+      if (nameA && nameB) {
+        return nameA.localeCompare(nameB);
+      }
+      if (nameA) return -1;
+      if (nameB) return 1;
+      return a.radar_id.localeCompare(b.radar_id);
+    });
+  }
+
+  async function loadRadars() {
+    setStatus('Fetching latest radar scans…');
+    clearImages();
+    dom.title.textContent = 'Select a radar';
+    dom.meta.textContent = '';
+    dom.updated.style.display = 'none';
+
+    const params = new URLSearchParams({
+      source: state.source,
+      include_metadata: 'true',
+    });
+    const prefix = dom.prefix.value.trim();
+    if (prefix) {
+      params.set('prefix', prefix);
+    }
+
     try {
-      const u = new URL(imgEl.dataset.src || '', window.location.origin);
-      const p = u.searchParams.get('path');
-      return p ? decodeURIComponent(p) : null;
-    } catch { return null; }
-  }
-
-  async function fetchAsImage(url) {
-    const r = await fetch(url, {cache:'no-store'});
-    if (!r.ok) {
-      const txt = await r.text();
-      throw new Error(`HTTP ${r.status} ${r.statusText}\n` + txt.slice(0,400));
+      const response = await fetch(`/api/base_reflectivity/latest?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error(`Server responded with ${response.status}`);
+      }
+      const payload = await response.json();
+      const radars = Array.isArray(payload.radars) ? payload.radars : [];
+      state.radars = radars;
+      sortRadars();
+      renderList();
+      setStatus(`Loaded ${radars.length} radar site${radars.length === 1 ? '' : 's'}.`);
+      if (radars.length) {
+        const defaultId = state.selectedId && radars.some((item) => item.radar_id === state.selectedId)
+          ? state.selectedId
+          : radars[0].radar_id;
+        handleSelect(defaultId);
+      }
+    } catch (error) {
+      console.error(error);
+      setStatus(`Unable to fetch radar list: ${error.message}`, true);
+      state.radars = [];
+      dom.list.innerHTML = '';
     }
-    const blob = await r.blob();                 // works even if server says application/json
-    const objUrl = URL.createObjectURL(blob);
-    imgEl.src = objUrl;
-    imgEl.dataset.src = url;                     // remember source URL for re-render on DBZ change
-    linkEl.href = url;
-    linkEl.style.display = 'inline-block';
   }
 
-  async function showResolved(path, dbz) {
-    const url = '/radar_filter_q?path=' + encodeURIComponent(path) + '&threshold=' + dbz;
-    await fetchAsImage(url);
-    msg("");
+  function wireEvents() {
+    dom.refresh.addEventListener('click', () => {
+      state.selectedId = null;
+      loadRadars();
+    });
+
+    dom.source.addEventListener('change', () => {
+      state.source = dom.source.value;
+      state.selectedId = null;
+      loadRadars();
+    });
+
+    dom.sort.addEventListener('change', () => {
+      state.sortBy = dom.sort.value;
+      sortRadars();
+      renderList();
+    });
+
+    dom.search.addEventListener('input', () => {
+      renderList();
+    });
   }
 
-  async function showAuto(basePath) {
-    msg("");
-    imgEl.removeAttribute('src');
-    linkEl.style.display = 'none';
-    const dbz = parseInt(dbzEl.value || '23', 10);
-    const candidates = [basePath];
-    if (!/\.nc$/i.test(basePath)) {
-      candidates.push(basePath + '.nc');
-      if (!/\.mdv\.nc$/i.test(basePath)) candidates.push(basePath + '.mdv.nc');
-    }
-    let lastErr = null;
-    for (const c of candidates) {
-      try { await showResolved(c, dbz); return; } catch(e){ lastErr = e; }
-    }
-    msg('Could not render any candidate:\n' + candidates.join('\n') + '\n\nLast error: ' + lastErr);
+  function init() {
+    wireEvents();
+    loadRadars();
   }
-
-  function wire() {
-    qs('refresh').onclick = listFiles;
-    qs('quick').onclick   = () => showAuto('radar_3_data/KMLB_SDUS52_TZ0MCO_202405151906.nc');
-    dbzEl.onchange        = () => { const cur = currentPathFromImg(); if (cur) showAuto(cur); };
-    listFiles();
-  }
-
-  window.addEventListener('error', (e) => { msg('JS error: ' + e.message); });
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', wire);
+    document.addEventListener('DOMContentLoaded', init);
   } else {
-    wire();
+    init();
   }
 })();

--- a/static/radar.js
+++ b/static/radar.js
@@ -82,15 +82,30 @@
     }
   }
 
+  function getLocationText(radar) {
+    const city = (radar.city || '').trim();
+    const stateCode = (radar.state || '').trim();
+    if (city && stateCode) {
+      return `${city}, ${stateCode}`;
+    }
+    if (city) {
+      return city;
+    }
+    if (stateCode) {
+      return stateCode;
+    }
+    return radar.location || 'Unknown location';
+  }
+
   function buildLocationLabel(radar) {
-    const location = radar.location || 'Unknown location';
+    const location = getLocationText(radar);
     return `${location} — ${radar.radar_id}`;
   }
 
   function updateSelectors() {
     const uniqueLocations = new Set();
     state.radars.forEach((radar) => {
-      uniqueLocations.add(radar.location || 'Unknown location');
+      uniqueLocations.add(getLocationText(radar));
     });
 
     const locationOptions = Array.from(uniqueLocations).sort((a, b) =>
@@ -206,7 +221,7 @@
       return;
     }
 
-    const location = radar.location || 'Unknown location';
+    const location = getLocationText(radar);
     dom.title.textContent = `${radar.radar_id}${location ? ' — ' + location : ''}`;
 
     const pieces = [];
@@ -246,7 +261,7 @@
   function filteredRadars() {
     return state.radars.filter((radar) => {
       if (state.prefixLocation) {
-        const location = radar.location || 'Unknown location';
+        const location = getLocationText(radar);
         if (location !== state.prefixLocation) {
           return false;
         }
@@ -281,7 +296,7 @@
 
       const location = document.createElement('span');
       location.className = 'radar-location';
-      location.textContent = radar.location || 'Unknown location';
+      location.textContent = getLocationText(radar);
       li.appendChild(location);
 
       li.addEventListener('click', () => handleSelect(radar.radar_id));
@@ -303,8 +318,8 @@
       if (sortBy === 'radar') {
         return a.radar_id.localeCompare(b.radar_id);
       }
-      const nameA = (a.location || '').toUpperCase();
-      const nameB = (b.location || '').toUpperCase();
+      const nameA = getLocationText(a).toUpperCase();
+      const nameB = getLocationText(b).toUpperCase();
       if (nameA && nameB) {
         return nameA.localeCompare(nameB);
       }
@@ -314,7 +329,11 @@
     });
   }
 
-  async function loadRadars() {
+  async function loadRadars(options = {}) {
+    const { attemptedFallback = false } = options;
+
+    const requestedSource = state.source;
+
     setStatus('Fetching latest radar scans…');
     clearImages();
     dom.title.textContent = 'Select a radar';
@@ -324,23 +343,56 @@
     const params = new URLSearchParams({
       source: state.source,
       include_metadata: 'true',
+      limit: '200',
     });
 
     try {
       const response = await fetch(`/api/base_reflectivity/latest?${params.toString()}`);
       if (!response.ok) {
+        if (response.status >= 500 && state.source !== 'local' && !attemptedFallback) {
+          setStatus('Remote source failed. Switching to local cache…', true);
+          state.source = 'local';
+          dom.source.value = 'local';
+          return loadRadars({ attemptedFallback: true });
+        }
         throw new Error(`Server responded with ${response.status}`);
       }
       const payload = await response.json();
       const radars = Array.isArray(payload.radars) ? payload.radars : [];
       state.radars = radars;
+
+      let fallbackMessage = '';
+      if (payload.source && payload.source !== state.source) {
+        state.source = payload.source;
+        dom.source.value = payload.source;
+        fallbackMessage = ` Remote source ${requestedSource.toUpperCase()} unavailable; showing ${payload.source.toUpperCase()} data.`;
+      }
+
       sortRadars();
       updateSelectors();
       renderList();
-      setStatus(`Loaded ${radars.length} radar site${radars.length === 1 ? '' : 's'}.`);
+      if (radars.length) {
+        setStatus(
+          `Loaded ${radars.length} radar site${radars.length === 1 ? '' : 's'} from ${state.source.toUpperCase()}.${fallbackMessage}`
+        );
+      } else {
+        setStatus(
+          'No radar data available. Try running scripts/ingest_last_hour.py and refresh.',
+          true
+        );
+      }
     } catch (error) {
       console.error(error);
-      setStatus(`Unable to fetch radar list: ${error.message}`, true);
+      if (!attemptedFallback && state.source !== 'local') {
+        state.source = 'local';
+        dom.source.value = 'local';
+        setStatus('Falling back to local cache…', true);
+        return loadRadars({ attemptedFallback: true });
+      }
+      setStatus(
+        `Unable to fetch radar list: ${error.message}. Ensure the ingest script has run or try another source.`,
+        true
+      );
       state.radars = [];
       dom.list.innerHTML = '';
     }

--- a/static/radar.js
+++ b/static/radar.js
@@ -1,0 +1,99 @@
+(function(){
+  const qs = (id) => document.getElementById(id);
+  const listEl   = qs('list');
+  const imgEl    = qs('radar');
+  const dbzEl    = qs('dbz');
+  const prefixEl = qs('prefix');
+  const linkEl   = qs('openLink');
+  const msgEl    = qs('msg');
+
+  function msg(s){ msgEl.textContent = s || ""; }
+
+  async function listFiles() {
+    try {
+      msg("");
+      listEl.innerHTML = "Loading...";
+      const r = await fetch('/radar_files', {cache:'no-store'});
+      if (!r.ok) throw new Error(`HTTP ${r.status} ${r.statusText}`);
+      const data = await r.json();
+      const pref = (prefixEl.value || '').trim().toUpperCase();
+      const all = Array.isArray(data.files) ? data.files : [];
+      const filtered = all.filter(f => pref ? f.toUpperCase().includes(pref) : true);
+      const header = document.createElement('div');
+      header.className = 'small';
+      header.textContent = `Total: ${all.length} | Showing: ${filtered.length}`;
+      listEl.innerHTML = '';
+      listEl.appendChild(header);
+      filtered.forEach(k => {
+        const a = document.createElement('a');
+        a.href = '#';
+        a.textContent = k;
+        a.style.display = 'block';
+        a.onclick = (e) => { e.preventDefault(); showAuto(k); };
+        listEl.appendChild(a);
+      });
+      if (filtered.length === 0) {
+        const d = document.createElement('div');
+        d.textContent = 'No matching items.';
+        listEl.appendChild(d);
+      }
+    } catch (e) {
+      listEl.textContent = 'Failed to list files: ' + e;
+    }
+  }
+
+  function currentPathFromImg() {
+    try {
+      const u = new URL(imgEl.dataset.src || '', window.location.origin);
+      const p = u.searchParams.get('path');
+      return p ? decodeURIComponent(p) : null;
+    } catch { return null; }
+  }
+
+  async function fetchAsImage(url) {
+    const r = await fetch(url, {cache:'no-store'});
+    if (!r.ok) {
+      const txt = await r.text();
+      throw new Error(`HTTP ${r.status} ${r.statusText}\n` + txt.slice(0,400));
+    }
+    const blob = await r.blob();                 // works even if server says application/json
+    const objUrl = URL.createObjectURL(blob);
+    imgEl.src = objUrl;
+    imgEl.dataset.src = url;                     // remember source URL for re-render on DBZ change
+    linkEl.href = url;
+    linkEl.style.display = 'inline-block';
+  }
+
+  async function showResolved(path, dbz) {
+    const url = '/radar_filter_q?path=' + encodeURIComponent(path) + '&threshold=' + dbz;
+    await fetchAsImage(url);
+    msg("");
+  }
+
+  async function showAuto(basePath) {
+    msg("");
+    imgEl.removeAttribute('src');
+    linkEl.style.display = 'none';
+    const dbz = parseInt(dbzEl.value || '23', 10);
+    const candidates = [basePath];
+    if (!/\.nc$/i.test(basePath)) {
+      candidates.push(basePath + '.nc');
+      if (!/\.mdv\.nc$/i.test(basePath)) candidates.push(basePath + '.mdv.nc');
+    }
+    let lastErr = null;
+    for (const c of candidates) {
+      try { await showResolved(c, dbz); return; } catch(e){ lastErr = e; }
+    }
+    msg('Could not render any candidate:\n' + candidates.join('\n') + '\n\nLast error: ' + lastErr);
+  }
+
+  function wire() {
+    qs('refresh').onclick = listFiles;
+    qs('quick').onclick   = () => showAuto('radar_3_data/KMLB_SDUS52_TZ0MCO_202405151906.nc');
+    dbzEl.onchange        = () => { const cur = currentPathFromImg(); if (cur) showAuto(cur); };
+    listFiles();
+  }
+
+  window.addEventListener('error', (e) => { msg('JS error: ' + e.message); });
+  document.addEventListener('DOMContentLoaded', wire);
+})();

--- a/static/radar.js
+++ b/static/radar.js
@@ -1,104 +1,392 @@
-(function(){
-  const qs = (id) => document.getElementById(id);
-  const listEl   = qs('list');
-  const imgEl    = qs('radar');
-  const dbzEl    = qs('dbz');
-  const prefixEl = qs('prefix');
-  const linkEl   = qs('openLink');
-  const msgEl    = qs('msg');
+(function () {
+  const dom = {
+    source: document.getElementById('sourceSelect'),
+    prefix: document.getElementById('prefixSelect'),
+    search: document.getElementById('searchSelect'),
+    sort: document.getElementById('sortSelect'),
+    refresh: document.getElementById('refreshBtn'),
+    list: document.getElementById('radarList'),
+    title: document.getElementById('selectedTitle'),
+    meta: document.getElementById('selectedMeta'),
+    updated: document.getElementById('selectedUpdated'),
+    images: document.getElementById('images'),
+    status: document.getElementById('status'),
+  };
 
-  function msg(s){ msgEl.textContent = s || ""; }
+  const state = {
+    source: dom.source.value,
+    radars: [],
+    selectedId: null,
+    sortBy: dom.sort.value,
+    prefixLocation: '',
+    searchSelection: '',
+  };
 
-  async function listFiles() {
-    try {
-      msg("");
-      listEl.innerHTML = "Loading...";
-      const r = await fetch('/radar_files', {cache:'no-store'});
-      if (!r.ok) throw new Error(`HTTP ${r.status} ${r.statusText}`);
-      const data = await r.json();
-      const pref = (prefixEl.value || '').trim().toUpperCase();
-      const all = Array.isArray(data.files) ? data.files : [];
-      const filtered = all.filter(f => pref ? f.toUpperCase().includes(pref) : true);
-      const header = document.createElement('div');
-      header.className = 'small';
-      header.textContent = `Total: ${all.length} | Showing: ${filtered.length}`;
-      listEl.innerHTML = '';
-      listEl.appendChild(header);
-      filtered.forEach(k => {
-        const a = document.createElement('a');
-        a.href = '#';
-        a.textContent = k;
-        a.style.display = 'block';
-        a.onclick = (e) => { e.preventDefault(); showAuto(k); };
-        listEl.appendChild(a);
-      });
-      if (filtered.length === 0) {
-        const d = document.createElement('div');
-        d.textContent = 'No matching items.';
-        listEl.appendChild(d);
+  function setStatus(message, isError = false) {
+    if (!message) {
+      dom.status.classList.add('hidden');
+      dom.status.textContent = '';
+      dom.status.classList.remove('error');
+      return;
+    }
+    dom.status.textContent = message;
+    dom.status.classList.remove('hidden');
+    dom.status.classList.toggle('error', isError);
+  }
+
+  function formatTilt(tilt) {
+    if (typeof tilt === 'number' && !Number.isNaN(tilt)) {
+      return `${tilt.toFixed(1)}° tilt`;
+    }
+    return 'Tilt';
+  }
+
+  function toUtcText(timestamp) {
+    if (!timestamp) {
+      return null;
+    }
+    const ts = timestamp.endsWith('Z') ? timestamp : `${timestamp}Z`;
+    const date = new Date(ts);
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+    return `${date.toUTCString()}`;
+  }
+
+  function clearImages() {
+    dom.images.innerHTML = '';
+  }
+
+  function populateSelect(select, options, preferredValue) {
+    const currentValue = select.value;
+    const desiredValue =
+      preferredValue !== undefined && preferredValue !== null
+        ? preferredValue
+        : currentValue;
+
+    select.innerHTML = '';
+    options.forEach((option) => {
+      const opt = document.createElement('option');
+      opt.value = option.value;
+      opt.textContent = option.label;
+      if (option.value === desiredValue) {
+        opt.selected = true;
       }
-    } catch (e) {
-      listEl.textContent = 'Failed to list files: ' + e;
+      select.appendChild(opt);
+    });
+
+    if (!options.some((opt) => opt.value === desiredValue)) {
+      select.value = options.length ? options[0].value : '';
+    } else {
+      select.value = desiredValue;
     }
   }
 
-  function currentPathFromImg() {
+  function buildLocationLabel(radar) {
+    const location = radar.location || 'Unknown location';
+    return `${location} — ${radar.radar_id}`;
+  }
+
+  function updateSelectors() {
+    const uniqueLocations = new Set();
+    state.radars.forEach((radar) => {
+      uniqueLocations.add(radar.location || 'Unknown location');
+    });
+
+    const locationOptions = Array.from(uniqueLocations).sort((a, b) =>
+      a.localeCompare(b)
+    );
+
+    const prefixOptions = [{ value: '', label: 'All locations' }];
+    locationOptions.forEach((location) => {
+      prefixOptions.push({ value: location, label: location });
+    });
+    populateSelect(dom.prefix, prefixOptions, state.prefixLocation);
+    state.prefixLocation = dom.prefix.value;
+
+    const searchOptions = [{ value: '', label: 'Select a radar…' }];
+    const sortedRadars = state.radars.slice().sort((a, b) => {
+      const labelA = buildLocationLabel(a);
+      const labelB = buildLocationLabel(b);
+      return labelA.localeCompare(labelB);
+    });
+    sortedRadars.forEach((radar) => {
+      searchOptions.push({ value: radar.radar_id, label: buildLocationLabel(radar) });
+    });
+    populateSelect(dom.search, searchOptions, state.searchSelection);
+    state.searchSelection = dom.search.value;
+  }
+
+  async function loadImage(img, key, view) {
+    if (!key) {
+      return;
+    }
+    const params = new URLSearchParams({
+      source: state.source,
+      key,
+      view,
+    });
     try {
-      const u = new URL(imgEl.dataset.src || '', window.location.origin);
-      const p = u.searchParams.get('path');
-      return p ? decodeURIComponent(p) : null;
-    } catch { return null; }
-  }
-
-  async function fetchAsImage(url) {
-    const r = await fetch(url, {cache:'no-store'});
-    if (!r.ok) {
-      const txt = await r.text();
-      throw new Error(`HTTP ${r.status} ${r.statusText}\n` + txt.slice(0,400));
+      const response = await fetch(`/api/file?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error(`Server responded with ${response.status}`);
+      }
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      img.src = url;
+      img.dataset.url = url;
+      const metadataHeader = response.headers.get('X-Radar-Metadata');
+      if (metadataHeader && view === 'zoom') {
+        try {
+          const metadata = JSON.parse(metadataHeader);
+          if (metadata.title) {
+            img.setAttribute('alt', metadata.title);
+          }
+        } catch (error) {
+          console.debug('Unable to parse radar metadata header', error);
+        }
+      }
+    } catch (error) {
+      console.error(error);
+      setStatus(`Failed to load radar image: ${error.message}`, true);
     }
-    const blob = await r.blob();                 // works even if server says application/json
-    const objUrl = URL.createObjectURL(blob);
-    imgEl.src = objUrl;
-    imgEl.dataset.src = url;                     // remember source URL for re-render on DBZ change
-    linkEl.href = url;
-    linkEl.style.display = 'inline-block';
   }
 
-  async function showResolved(path, dbz) {
-    const url = '/radar_filter_q?path=' + encodeURIComponent(path) + '&threshold=' + dbz;
-    await fetchAsImage(url);
-    msg("");
-  }
-
-  async function showAuto(basePath) {
-    msg("");
-    imgEl.removeAttribute('src');
-    linkEl.style.display = 'none';
-    const dbz = parseInt(dbzEl.value || '23', 10);
-    const candidates = [basePath];
-    if (!/\.nc$/i.test(basePath)) {
-      candidates.push(basePath + '.nc');
-      if (!/\.mdv\.nc$/i.test(basePath)) candidates.push(basePath + '.mdv.nc');
+  function renderImages(radar) {
+    clearImages();
+    if (!radar || !Array.isArray(radar.products)) {
+      return;
     }
-    let lastErr = null;
-    for (const c of candidates) {
-      try { await showResolved(c, dbz); return; } catch(e){ lastErr = e; }
+    radar.products.forEach((product) => {
+      const card = document.createElement('div');
+      card.className = 'tilt-card';
+
+      const heading = document.createElement('h3');
+      const tiltLabel = formatTilt(product.tilt_degrees);
+      heading.textContent = `${product.code} — ${tiltLabel}`;
+      card.appendChild(heading);
+
+      const stamp = toUtcText(product.timestamp);
+      if (stamp) {
+        const stampEl = document.createElement('div');
+        stampEl.className = 'meta';
+        stampEl.textContent = `Scan time: ${stamp}`;
+        card.appendChild(stampEl);
+      }
+
+      const pair = document.createElement('div');
+      pair.className = 'view-pair';
+
+      ['overview', 'zoom'].forEach((view) => {
+        const container = document.createElement('div');
+        container.className = 'view';
+        const title = document.createElement('div');
+        title.className = 'view-title';
+        title.textContent = view === 'overview' ? 'State overview' : 'Local zoom';
+        const img = document.createElement('img');
+        img.alt = `${product.code} ${view}`;
+        img.loading = 'lazy';
+        container.appendChild(title);
+        container.appendChild(img);
+        pair.appendChild(container);
+        loadImage(img, product.key, view);
+      });
+
+      card.appendChild(pair);
+      dom.images.appendChild(card);
+    });
+  }
+
+  function updateSelection(radar) {
+    if (!radar) {
+      dom.title.textContent = 'Select a radar';
+      dom.meta.textContent = '';
+      dom.updated.style.display = 'none';
+      clearImages();
+      return;
     }
-    msg('Could not render any candidate:\n' + candidates.join('\n') + '\n\nLast error: ' + lastErr);
+
+    const location = radar.location || 'Unknown location';
+    dom.title.textContent = `${radar.radar_id}${location ? ' — ' + location : ''}`;
+
+    const pieces = [];
+    if (radar.product_name) {
+      pieces.push(radar.product_name);
+    }
+    if (radar.elevation_degrees != null) {
+      pieces.push(`${radar.elevation_degrees.toFixed(1)}° tilt`);
+    }
+    dom.meta.textContent = pieces.join(' • ');
+
+    const updatedText = toUtcText(radar.product_time || radar.volume_time);
+    if (updatedText) {
+      dom.updated.textContent = `Updated ${updatedText}`;
+      dom.updated.style.display = 'inline-flex';
+    } else {
+      dom.updated.style.display = 'none';
+    }
+
+    renderImages(radar);
   }
 
-  function wire() {
-    qs('refresh').onclick = listFiles;
-    qs('quick').onclick   = () => showAuto('radar_3_data/KMLB_SDUS52_TZ0MCO_202405151906.nc');
-    dbzEl.onchange        = () => { const cur = currentPathFromImg(); if (cur) showAuto(cur); };
-    listFiles();
+  function setActiveListItem() {
+    const items = dom.list.querySelectorAll('li');
+    items.forEach((li) => {
+      li.classList.toggle('active', li.dataset.radarId === state.selectedId);
+    });
   }
 
-  window.addEventListener('error', (e) => { msg('JS error: ' + e.message); });
+  function handleSelect(radarId) {
+    state.selectedId = radarId;
+    const radar = state.radars.find((item) => item.radar_id === radarId);
+    setActiveListItem();
+    updateSelection(radar);
+  }
+
+  function filteredRadars() {
+    return state.radars.filter((radar) => {
+      if (state.prefixLocation) {
+        const location = radar.location || 'Unknown location';
+        if (location !== state.prefixLocation) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }
+
+  function renderList() {
+    const items = filteredRadars();
+
+    dom.list.innerHTML = '';
+
+    if (!items.length) {
+      const placeholder = document.createElement('li');
+      placeholder.textContent = 'No radar sites match the current filters.';
+      placeholder.style.cursor = 'default';
+      placeholder.style.color = '#64748b';
+      dom.list.appendChild(placeholder);
+      updateSelection(null);
+      return;
+    }
+
+    items.forEach((radar) => {
+      const li = document.createElement('li');
+      li.dataset.radarId = radar.radar_id;
+
+      const code = document.createElement('span');
+      code.className = 'radar-code';
+      code.textContent = radar.radar_id;
+      li.appendChild(code);
+
+      const location = document.createElement('span');
+      location.className = 'radar-location';
+      location.textContent = radar.location || 'Unknown location';
+      li.appendChild(location);
+
+      li.addEventListener('click', () => handleSelect(radar.radar_id));
+      dom.list.appendChild(li);
+    });
+
+    if (!state.selectedId || !items.some((item) => item.radar_id === state.selectedId)) {
+      state.selectedId = items[0].radar_id;
+    }
+
+    setActiveListItem();
+    const selectedRadar = state.radars.find((item) => item.radar_id === state.selectedId);
+    updateSelection(selectedRadar || null);
+  }
+
+  function sortRadars() {
+    const sortBy = state.sortBy;
+    state.radars.sort((a, b) => {
+      if (sortBy === 'radar') {
+        return a.radar_id.localeCompare(b.radar_id);
+      }
+      const nameA = (a.location || '').toUpperCase();
+      const nameB = (b.location || '').toUpperCase();
+      if (nameA && nameB) {
+        return nameA.localeCompare(nameB);
+      }
+      if (nameA) return -1;
+      if (nameB) return 1;
+      return a.radar_id.localeCompare(b.radar_id);
+    });
+  }
+
+  async function loadRadars() {
+    setStatus('Fetching latest radar scans…');
+    clearImages();
+    dom.title.textContent = 'Select a radar';
+    dom.meta.textContent = '';
+    dom.updated.style.display = 'none';
+
+    const params = new URLSearchParams({
+      source: state.source,
+      include_metadata: 'true',
+    });
+
+    try {
+      const response = await fetch(`/api/base_reflectivity/latest?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error(`Server responded with ${response.status}`);
+      }
+      const payload = await response.json();
+      const radars = Array.isArray(payload.radars) ? payload.radars : [];
+      state.radars = radars;
+      sortRadars();
+      updateSelectors();
+      renderList();
+      setStatus(`Loaded ${radars.length} radar site${radars.length === 1 ? '' : 's'}.`);
+    } catch (error) {
+      console.error(error);
+      setStatus(`Unable to fetch radar list: ${error.message}`, true);
+      state.radars = [];
+      dom.list.innerHTML = '';
+    }
+  }
+
+  function wireEvents() {
+    dom.refresh.addEventListener('click', () => {
+      state.selectedId = null;
+      loadRadars();
+    });
+
+    dom.source.addEventListener('change', () => {
+      state.source = dom.source.value;
+      state.selectedId = null;
+      state.prefixLocation = '';
+      state.searchSelection = '';
+      loadRadars();
+    });
+
+    dom.sort.addEventListener('change', () => {
+      state.sortBy = dom.sort.value;
+      sortRadars();
+      renderList();
+    });
+
+    dom.prefix.addEventListener('change', () => {
+      state.prefixLocation = dom.prefix.value;
+      renderList();
+    });
+
+    dom.search.addEventListener('change', () => {
+      state.searchSelection = dom.search.value;
+      if (state.searchSelection) {
+        handleSelect(state.searchSelection);
+      }
+    });
+  }
+
+  function init() {
+    wireEvents();
+    loadRadars();
+  }
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', wire);
+    document.addEventListener('DOMContentLoaded', init);
   } else {
-    wire();
+    init();
   }
 })();

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,6 @@
     <title>Index</title>
 </head>
 <body>
-    <img src="{{url_for('static', filename='radar_filter.jpg')}}" />
+    <img src="{{url_for('static', filename='radar_filter.png')}}" />
 </body>
 </html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+
+class _DummySession:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+
+    def client(self, *args, **kwargs):  # pragma: no cover - fallback for unexpected calls
+        raise RuntimeError("S3 client not stubbed in tests")
+
+
+def _install_stub(module_name: str, module):
+    if module_name not in sys.modules:
+        sys.modules[module_name] = module
+
+
+_install_stub("dotenv", SimpleNamespace(load_dotenv=lambda: None))
+_install_stub("boto3", SimpleNamespace(session=SimpleNamespace(Session=_DummySession)))
+_install_stub("flask_cors", SimpleNamespace(CORS=lambda *args, **kwargs: None))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import app as radar_app
+
+
+class StubDataSource:
+    def __init__(self, keys: Optional[List[str]] = None) -> None:
+        self.keys = keys or ["sample_key"]
+        self.last_threshold = None
+
+    def list_keys(self, prefix: Optional[str] = None, limit: int = 50) -> List[str]:
+        results = self.keys
+        if prefix:
+            results = [k for k in results if prefix in k]
+        return results[:limit]
+
+    def get_image_for_key(
+        self, key: str, threshold: Optional[int] = None
+    ) -> Tuple[bytes, Dict[str, object]]:
+        self.last_threshold = threshold
+        metadata = {
+            "content_type": "image/png",
+            "bounds": {
+                "min_lat": 0.0,
+                "max_lat": 1.0,
+                "min_lon": -1.0,
+                "max_lon": 1.0,
+            },
+            "key": key,
+        }
+        return b"fake-bytes", metadata
+
+
+@pytest.fixture(autouse=True)
+def clear_cache(monkeypatch):
+    monkeypatch.setattr(radar_app, "_data_source_cache", {})
+    yield
+
+
+def test_api_files_returns_keys(monkeypatch):
+    monkeypatch.setattr(radar_app, "get_data_source", lambda source: StubDataSource(["A", "B"]))
+    client = radar_app.app.test_client()
+    response = client.get("/api/files?source=s3&limit=2")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload == {"keys": ["A", "B"], "count": 2}
+
+
+def test_api_file_returns_image_bytes(monkeypatch):
+    stub = StubDataSource(["A"])
+    monkeypatch.setattr(radar_app, "get_data_source", lambda source: stub)
+    client = radar_app.app.test_client()
+    response = client.get("/api/file?source=s3&key=A&threshold=23")
+    assert response.status_code == 200
+    assert response.data == b"fake-bytes"
+    assert response.headers["Content-Type"] == "image/png"
+    bounds_header = json.loads(response.headers["X-Radar-Bounds"])
+    assert bounds_header["min_lat"] == 0.0
+    assert stub.last_threshold == 23

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("flask")
+pytest.importorskip("numpy")
+pytest.importorskip("metpy")
+pytest.importorskip("cartopy")
+pytest.importorskip("matplotlib")
+
+import app as radar_app
+
+
+@pytest.fixture
+def client():
+    return radar_app.app.test_client()
+
+
+def test_radar_files_ok(client):
+    response = client.get("/radar_files")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert isinstance(payload, dict)
+    assert "files" in payload
+    assert isinstance(payload["files"], list)
+
+
+def test_filter_returns_image(client, tmp_path, monkeypatch):
+    sample = Path("radar_3_data/KMLB_SDUS52_TZ0MCO_202405151906.nc")
+    if not sample.exists():
+        pytest.skip("Sample radar file missing")
+
+    response = client.get(
+        "/radar_filter_q",
+        query_string={
+            "path": str(sample),
+            "threshold": 23,
+        },
+    )
+    assert response.status_code == 200
+    content_type = response.headers.get("Content-Type", "")
+    assert content_type.startswith("image/")
+    assert len(response.data) > 1000

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Dict, Optional, Tuple
 
 import pytest
 
@@ -43,3 +44,39 @@ def test_filter_returns_image(client, tmp_path, monkeypatch):
     content_type = response.headers.get("Content-Type", "")
     assert content_type.startswith("image/")
     assert len(response.data) > 1000
+
+
+class DummyDataSource:
+    def __init__(self):
+        self.keys = [
+            "KMLB_N0B_20240515_180000",
+            "KMLB_N1B_20240515_180500",
+            "KTLX_N0B_20240515_180200",
+            "KTLX_N0B_20240515_181200",
+        ]
+
+    def list_keys(self, prefix: Optional[str] = None, limit: int = 50):
+        return self.keys[:limit]
+
+    def get_image_for_key(
+        self, key: str, threshold: Optional[int] = None, view: str = "combined"
+    ) -> Tuple[bytes, Dict[str, object]]:
+        return b"image-bytes", {"content_type": "image/png", "bounds": None, "key": key}
+
+    def get_level3_bytes(self, key: str) -> bytes:
+        raise AssertionError("metadata access should be disabled in this test")
+
+
+def test_latest_base_reflectivity_endpoint(monkeypatch, client):
+    monkeypatch.setitem(radar_app._DATA_SOURCE_FACTORIES, "dummy", DummyDataSource)
+    response = client.get(
+        "/api/base_reflectivity/latest",
+        query_string={"source": "dummy", "include_metadata": "false"},
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["count"] == 2
+    radar_ids = {item["radar_id"] for item in payload["radars"]}
+    assert radar_ids == {"KMLB", "KTLX"}
+    for radar in payload["radars"]:
+        assert "products" in radar and radar["products"]

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from services.data_sources.s3_source import S3DataSource
+from services.data_sources.thread_source import ThreadDataSource
+
+
+class DummyBody:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+def test_s3_list_keys_respects_limit():
+    responses = [
+        {
+            "Contents": [{"Key": f"file_{i}"} for i in range(5)],
+            "IsTruncated": False,
+        }
+    ]
+
+    class Client:
+        def list_objects_v2(self, **kwargs):
+            return responses.pop(0)
+
+        def get_object(self, **kwargs):  # pragma: no cover - not used in this test
+            raise AssertionError("unexpected call")
+
+    source = S3DataSource(bucket="demo", client=Client())
+    keys = source.list_keys(limit=3)
+    assert keys == ["file_0", "file_1", "file_2"]
+
+
+def test_s3_get_image_for_key_uses_processor(monkeypatch):
+    class Client:
+        def list_objects_v2(self, **kwargs):  # pragma: no cover - not used
+            return {}
+
+        def get_object(self, **kwargs):
+            return {"Body": DummyBody(b"level3-bytes")}
+
+    processed = SimpleNamespace(content=b"png-bytes", content_type="image/png", bounds={"min_lat": 0.0})
+    monkeypatch.setattr(
+        "services.data_sources.s3_source.process_level3_bytes",
+        lambda data, threshold=None: processed,
+    )
+
+    source = S3DataSource(bucket="demo", client=Client())
+    content, metadata = source.get_image_for_key("demo-key", threshold=10)
+
+    assert content == b"png-bytes"
+    assert metadata["content_type"] == "image/png"
+    assert metadata["bounds"] == {"min_lat": 0.0}
+    assert metadata["key"] == "demo-key"
+
+
+CATALOG_XML = """
+<catalog xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0">
+  <dataset name="root">
+    <dataset name="first" urlPath="TBW/example1" />
+    <dataset name="second" urlPath="KTLX/example2" />
+  </dataset>
+</catalog>
+"""
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, content: bytes) -> None:
+        self.status_code = status_code
+        self.content = content
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, url, timeout=0):
+        self.calls.append(url)
+        if url.endswith("catalog.xml"):
+            return FakeResponse(200, CATALOG_XML.encode("utf-8"))
+        return FakeResponse(200, b"level3-thread")
+
+
+def test_thread_list_keys_filters_prefix():
+    session = FakeSession()
+    source = ThreadDataSource(base_url="https://example.test/thredds/catalog", session=session)
+    keys = source.list_keys(prefix="TBW", limit=5)
+    assert keys == ["TBW/example1"]
+
+
+def test_thread_get_image_for_key(monkeypatch):
+    session = FakeSession()
+    processed = SimpleNamespace(content=b"png-bytes", content_type="image/png", bounds=None)
+    monkeypatch.setattr(
+        "services.data_sources.thread_source.process_level3_bytes",
+        lambda data, threshold=None: processed,
+    )
+
+    source = ThreadDataSource(base_url="https://example.test/thredds/catalog", session=session)
+    content, metadata = source.get_image_for_key("TBW/example1", threshold=12)
+
+    assert content == b"png-bytes"
+    assert metadata["content_type"] == "image/png"
+    assert metadata["key"] == "TBW/example1"
+    assert metadata["source_url"].endswith("TBW/example1")

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -46,10 +46,27 @@ def test_s3_get_image_for_key_uses_processor(monkeypatch):
         def get_object(self, **kwargs):
             return {"Body": DummyBody(b"level3-bytes")}
 
-    processed = SimpleNamespace(content=b"png-bytes", content_type="image/png", bounds={"min_lat": 0.0})
+    processed = SimpleNamespace(
+        content=b"png-bytes",
+        content_type="image/png",
+        bounds={"min_lat": 0.0},
+        metadata={"title": "Demo"},
+    )
     monkeypatch.setattr(
         "services.data_sources.s3_source.process_level3_bytes",
-        lambda data, threshold=None: processed,
+        lambda data, threshold=None, view="combined": processed,
+    )
+    monkeypatch.setattr(
+        "services.data_sources.s3_source.local_cache.get_cached_bytes",
+        lambda key: None,
+    )
+
+    def _store_bytes(key, payload):
+        return Path("/tmp") / key.replace("/", "_")
+
+    monkeypatch.setattr(
+        "services.data_sources.s3_source.local_cache.store_bytes",
+        _store_bytes,
     )
 
     source = S3DataSource(bucket="demo", client=Client())
@@ -101,10 +118,27 @@ def test_thread_list_keys_filters_prefix():
 
 def test_thread_get_image_for_key(monkeypatch):
     session = FakeSession()
-    processed = SimpleNamespace(content=b"png-bytes", content_type="image/png", bounds=None)
+    processed = SimpleNamespace(
+        content=b"png-bytes",
+        content_type="image/png",
+        bounds=None,
+        metadata={},
+    )
     monkeypatch.setattr(
         "services.data_sources.thread_source.process_level3_bytes",
-        lambda data, threshold=None: processed,
+        lambda data, threshold=None, view="combined": processed,
+    )
+    monkeypatch.setattr(
+        "services.data_sources.thread_source.local_cache.get_cached_bytes",
+        lambda key: None,
+    )
+
+    def _store_thread_bytes(key, payload):
+        return Path("/tmp") / key.replace("/", "_")
+
+    monkeypatch.setattr(
+        "services.data_sources.thread_source.local_cache.store_bytes",
+        _store_thread_bytes,
     )
 
     source = ThreadDataSource(base_url="https://example.test/thredds/catalog", session=session)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -46,10 +46,15 @@ def test_s3_get_image_for_key_uses_processor(monkeypatch):
         def get_object(self, **kwargs):
             return {"Body": DummyBody(b"level3-bytes")}
 
-    processed = SimpleNamespace(content=b"png-bytes", content_type="image/png", bounds={"min_lat": 0.0})
+    processed = SimpleNamespace(
+        content=b"png-bytes",
+        content_type="image/png",
+        bounds={"min_lat": 0.0},
+        metadata={"title": "Demo"},
+    )
     monkeypatch.setattr(
         "services.data_sources.s3_source.process_level3_bytes",
-        lambda data, threshold=None: processed,
+        lambda data, threshold=None, view="combined": processed,
     )
 
     source = S3DataSource(bucket="demo", client=Client())
@@ -101,10 +106,15 @@ def test_thread_list_keys_filters_prefix():
 
 def test_thread_get_image_for_key(monkeypatch):
     session = FakeSession()
-    processed = SimpleNamespace(content=b"png-bytes", content_type="image/png", bounds=None)
+    processed = SimpleNamespace(
+        content=b"png-bytes",
+        content_type="image/png",
+        bounds=None,
+        metadata={},
+    )
     monkeypatch.setattr(
         "services.data_sources.thread_source.process_level3_bytes",
-        lambda data, threshold=None: processed,
+        lambda data, threshold=None, view="combined": processed,
     )
 
     source = ThreadDataSource(base_url="https://example.test/thredds/catalog", session=session)


### PR DESCRIPTION
###  Summary
- Adds /health liveness endpoint
- Adds /radar_files for dataset discovery
- Adds /radar_filter_q helper that returns the encoded filter route
- No changes to existing filter logic
- Dockerfile: make static dir creation idempotent

### How to run
1) docker compose up --build
2) Open:
   - http://localhost:5000/health  -> {"status":"ok"}
   - http://localhost:5000/radar_files  -> JSON list of files
   - http://localhost:5000/radar_filter_q?path=radar_3_data/KMLB_SDUS52_TZ0MCO_202405151912&threshold=23
     Copy the "route" and open: http://localhost:5000<route>
3) Existing filter route continues to work as before.
